### PR TITLE
Add more packages to "dind" for proper "devicemapper" support

### DIFF
--- a/1.10/dind/Dockerfile
+++ b/1.10/dind/Dockerfile
@@ -4,7 +4,9 @@ FROM docker:1.10
 RUN apk add --no-cache \
 		btrfs-progs \
 		e2fsprogs \
+		e2fsprogs-extra \
 		iptables \
+		xfsprogs \
 		xz
 
 # TODO aufs-tools

--- a/1.11-rc/dind/Dockerfile
+++ b/1.11-rc/dind/Dockerfile
@@ -4,7 +4,9 @@ FROM docker:1.11-rc
 RUN apk add --no-cache \
 		btrfs-progs \
 		e2fsprogs \
+		e2fsprogs-extra \
 		iptables \
+		xfsprogs \
 		xz
 
 # TODO aufs-tools

--- a/1.9/dind/Dockerfile
+++ b/1.9/dind/Dockerfile
@@ -4,7 +4,9 @@ FROM docker:1.9
 RUN apk add --no-cache \
 		btrfs-progs \
 		e2fsprogs \
+		e2fsprogs-extra \
 		iptables \
+		xfsprogs \
 		xz
 
 # TODO aufs-tools


### PR DESCRIPTION
As much as we can support `devicemapper`, that is -- it still requires `--storage-opt dm.override_udev_sync_check=true` due to our static binary.

Fixes #8