### PR TITLE
Added DOCKER_DAEMON_ARGS environment variable support

### DIFF
--- a/1.10/dind/dockerd-entrypoint.sh
+++ b/1.10/dind/dockerd-entrypoint.sh
@@ -6,13 +6,14 @@ if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 		--host=unix:///var/run/docker.sock \
 		--host=tcp://0.0.0.0:2375 \
 		--storage-driver=vfs \
+		"${DOCKER_DAEMON_ARGS}" \
 		"$@"
 fi
 
 if [ "$1" = 'docker' -a "$2" = 'daemon' ]; then
 	# if we're running Docker, let's pipe through dind
 	# (and we'll run dind explicitly with "sh" since its shebang is /bin/bash)
-	set -- sh "$(which dind)" "$@"
+	set -- sh "$(which dind)" "${DOCKER_DAEMON_ARGS}" "$@"
 fi
 
 exec "$@"

--- a/1.11/dind/dockerd-entrypoint.sh
+++ b/1.11/dind/dockerd-entrypoint.sh
@@ -6,13 +6,14 @@ if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 		--host=unix:///var/run/docker.sock \
 		--host=tcp://0.0.0.0:2375 \
 		--storage-driver=vfs \
+		"${DOCKER_DAEMON_ARGS}" \
 		"$@"
 fi
 
 if [ "$1" = 'docker' -a "$2" = 'daemon' ]; then
 	# if we're running Docker, let's pipe through dind
 	# (and we'll run dind explicitly with "sh" since its shebang is /bin/bash)
-	set -- sh "$(which dind)" "$@"
+	set -- sh "$(which dind)" "${DOCKER_DAEMON_ARGS}" "$@"
 fi
 
 exec "$@"

--- a/1.12-rc/dind/dockerd-entrypoint.sh
+++ b/1.12-rc/dind/dockerd-entrypoint.sh
@@ -6,13 +6,14 @@ if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 		--host=unix:///var/run/docker.sock \
 		--host=tcp://0.0.0.0:2375 \
 		--storage-driver=vfs \
+		"${DOCKER_DAEMON_ARGS}" \
 		"$@"
 fi
 
 if [ "$1" = 'docker' -a "$2" = 'daemon' ]; then
 	# if we're running Docker, let's pipe through dind
 	# (and we'll run dind explicitly with "sh" since its shebang is /bin/bash)
-	set -- sh "$(which dind)" "$@"
+	set -- sh "$(which dind)" "${DOCKER_DAEMON_ARGS}" "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
This image is really awesome! But it lacks the support for an environment variable based docker daemon configuration. It would be really helpful to support both approaches, the entrypoint arguments and an additional `DOCKER_DAEMON_ARGS` variable. 

This comes in very handy for a CI build, when an user can't change the way how a dependent service is started, except of passing environment variables. 

Moreover it's documented that way on [dind](https://github.com/jpetazzo/dind#daemon-configuration) itself.