### PR TITLE
Adding Docker Opts to entrypoint

### DIFF
--- a/1.11/dind/dockerd-entrypoint.sh
+++ b/1.11/dind/dockerd-entrypoint.sh
@@ -6,6 +6,7 @@ if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 		--host=unix:///var/run/docker.sock \
 		--host=tcp://0.0.0.0:2375 \
 		--storage-driver=vfs \
+		$DOCKER_OPTS \
 		"$@"
 fi
 

--- a/1.12/dind/dockerd-entrypoint.sh
+++ b/1.12/dind/dockerd-entrypoint.sh
@@ -6,6 +6,7 @@ if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
 		--host=unix:///var/run/docker.sock \
 		--host=tcp://0.0.0.0:2375 \
 		--storage-driver=vfs \
+		$DOCKER_OPTS \
 		"$@"
 fi
 


### PR DESCRIPTION
Allowing docker opts in entry point to pass arguments to the daemon via environment variables as well as CMD arguments.