### PR TITLE
Add new "experimental" variant now that 1.12+ has official "experimental" releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: bash
 services: docker
 
 env:
-  - VERSION=1.12
-  - VERSION=1.11
+  - VERSION=1.12 VARIANT=
+  - VERSION=1.12 VARIANT=experimental
+  - VERSION=1.11 VARIANT=
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images

--- a/1.12/experimental/Dockerfile
+++ b/1.12/experimental/Dockerfile
@@ -1,0 +1,24 @@
+FROM alpine:3.4
+
+RUN apk add --no-cache \
+		ca-certificates \
+		curl \
+		openssl
+
+ENV DOCKER_BUCKET experimental.docker.com
+ENV DOCKER_VERSION 1.12.1
+ENV DOCKER_SHA256 f92fe0630dd1f20d9678cd7e4043018566e3737001f53171274a4a6ed6baaa08
+
+RUN set -x \
+	&& curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
+	&& echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
+	&& tar -xzvf docker.tgz \
+	&& mv docker/* /usr/local/bin/ \
+	&& rmdir docker \
+	&& rm docker.tgz \
+	&& docker -v
+
+COPY docker-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["sh"]

--- a/1.12/experimental/dind/Dockerfile
+++ b/1.12/experimental/dind/Dockerfile
@@ -1,0 +1,32 @@
+FROM docker:1.12-experimental
+
+# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
+RUN apk add --no-cache \
+		btrfs-progs \
+		e2fsprogs \
+		e2fsprogs-extra \
+		iptables \
+		xfsprogs \
+		xz
+
+# TODO aufs-tools
+
+# set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
+RUN set -x \
+	&& addgroup -S dockremap \
+	&& adduser -S -G dockremap dockremap \
+	&& echo 'dockremap:165536:65536' >> /etc/subuid \
+	&& echo 'dockremap:165536:65536' >> /etc/subgid
+
+ENV DIND_COMMIT 3b5fac462d21ca164b3778647420016315289034
+
+RUN wget "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -O /usr/local/bin/dind \
+	&& chmod +x /usr/local/bin/dind
+
+COPY dockerd-entrypoint.sh /usr/local/bin/
+
+VOLUME /var/lib/docker
+EXPOSE 2375
+
+ENTRYPOINT ["dockerd-entrypoint.sh"]
+CMD []

--- a/1.12/experimental/dind/dockerd-entrypoint.sh
+++ b/1.12/experimental/dind/dockerd-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
+	set -- docker daemon \
+		--host=unix:///var/run/docker.sock \
+		--host=tcp://0.0.0.0:2375 \
+		--storage-driver=vfs \
+		"$@"
+fi
+
+if [ "$1" = 'docker' -a "$2" = 'daemon' ]; then
+	# if we're running Docker, let's pipe through dind
+	# (and we'll run dind explicitly with "sh" since its shebang is /bin/bash)
+	set -- sh "$(which dind)" "$@"
+fi
+
+exec "$@"

--- a/1.12/experimental/docker-entrypoint.sh
+++ b/1.12/experimental/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+	set -- docker "$@"
+fi
+
+# if our command is a valid Docker subcommand, let's invoke it through Docker instead
+# (this allows for "docker run docker ps", etc)
+if docker "$1" --help > /dev/null 2>&1; then
+	set -- docker "$@"
+fi
+
+# if we have "--link some-docker:docker" and not DOCKER_HOST, let's set DOCKER_HOST automatically
+if [ -z "$DOCKER_HOST" -a "$DOCKER_PORT_2375_TCP" ]; then
+	export DOCKER_HOST='tcp://docker:2375'
+fi
+
+exec "$@"

--- a/1.12/experimental/git/Dockerfile
+++ b/1.12/experimental/git/Dockerfile
@@ -1,0 +1,5 @@
+FROM docker:1.12-experimental
+
+RUN apk add --no-cache \
+		git \
+		openssh-client

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -70,12 +70,16 @@ for version in "${versions[@]}"; do
 		Directory: $version
 	EOE
 
-	for variant in dind git; do
+	for variant in \
+		dind git \
+		experimental experimental/dind experimental/git \
+	; do
 		[ -f "$version/$variant/Dockerfile" ] || continue
 
 		commit="$(dirCommit "$version/$variant")"
 
-		variantAliases=( "${versionAliases[@]/%/-$variant}" )
+		slash='/'
+		variantAliases=( "${versionAliases[@]/%/-${variant//$slash/-}}" )
 		variantAliases=( "${variantAliases[@]//latest-/}" )
 
 		echo


### PR DESCRIPTION
Closes #21

```diff
commit eb714a73e7e3f87705f468c3c6e9f4e316136bf5
Author: Tianon Gravi <admwiggin@gmail.com>
Date:   Mon Aug 22 12:06:09 2016 -0700

    Add new "experimental" variant now that 1.12+ has official "experimental" releases

diff --git a/.travis.yml b/.travis.yml
index cf4accc..c49c7e7 100644
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: bash
 services: docker
 
 env:
-  - VERSION=1.12
-  - VERSION=1.11
+  - VERSION=1.12 VARIANT=
+  - VERSION=1.12 VARIANT=experimental
+  - VERSION=1.11 VARIANT=
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images
diff --git a/1.12/Dockerfile b/1.12/experimental/Dockerfile
similarity index 79%
copy from 1.12/Dockerfile
copy to 1.12/experimental/Dockerfile
index 4764465..0852d0b 100644
--- a/1.12/Dockerfile
+++ b/1.12/experimental/Dockerfile
@@ -5,9 +5,9 @@ RUN apk add --no-cache \
 		curl \
 		openssl
 
-ENV DOCKER_BUCKET get.docker.com
+ENV DOCKER_BUCKET experimental.docker.com
 ENV DOCKER_VERSION 1.12.1
-ENV DOCKER_SHA256 05ceec7fd937e1416e5dce12b0b6e1c655907d349d52574319a1e875077ccb79
+ENV DOCKER_SHA256 f92fe0630dd1f20d9678cd7e4043018566e3737001f53171274a4a6ed6baaa08
 
 RUN set -x \
 	&& curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
diff --git a/1.12/dind/Dockerfile b/1.12/experimental/dind/Dockerfile
similarity index 96%
copy from 1.12/dind/Dockerfile
copy to 1.12/experimental/dind/Dockerfile
index 7621999..38fcdc9 100644
--- a/1.12/dind/Dockerfile
+++ b/1.12/experimental/dind/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:1.12
+FROM docker:1.12-experimental
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN apk add --no-cache \
diff --git a/1.12/dind/dockerd-entrypoint.sh b/1.12/experimental/dind/dockerd-entrypoint.sh
similarity index 100%
copy from 1.12/dind/dockerd-entrypoint.sh
copy to 1.12/experimental/dind/dockerd-entrypoint.sh
diff --git a/1.12/docker-entrypoint.sh b/1.12/experimental/docker-entrypoint.sh
similarity index 100%
copy from 1.12/docker-entrypoint.sh
copy to 1.12/experimental/docker-entrypoint.sh
diff --git a/1.11/git/Dockerfile b/1.12/experimental/git/Dockerfile
similarity index 62%
copy from 1.11/git/Dockerfile
copy to 1.12/experimental/git/Dockerfile
index 382e08c..cf72e00 100644
--- a/1.11/git/Dockerfile
+++ b/1.12/experimental/git/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:1.11
+FROM docker:1.12-experimental
 
 RUN apk add --no-cache \
 		git \
diff --git a/generate-stackbrew-library.sh b/generate-stackbrew-library.sh
index 9b78831..5d55a09 100755
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -70,12 +70,16 @@ for version in "${versions[@]}"; do
 		Directory: $version
 	EOE
 
-	for variant in dind git; do
+	for variant in \
+		dind git \
+		experimental experimental/dind experimental/git \
+	; do
 		[ -f "$version/$variant/Dockerfile" ] || continue
 
 		commit="$(dirCommit "$version/$variant")"
 
-		variantAliases=( "${versionAliases[@]/%/-$variant}" )
+		slash='/'
+		variantAliases=( "${versionAliases[@]/%/-${variant//$slash/-}}" )
 		variantAliases=( "${variantAliases[@]//latest-/}" )
 
 		echo
diff --git a/update.sh b/update.sh
index dbe22aa..630a322 100755
--- a/update.sh
+++ b/update.sh
@@ -26,31 +26,34 @@ for version in "${versions[@]}"; do
 		echo >&2 "warning: cannot find full version for $version"
 		continue
 	fi
-	bucket='get.docker.com'
-	if [ "$rcVersion" != "$version" ]; then
-		bucket='test.docker.com'
-	fi
-	case "$rcVersion" in
-		1.9|1.10)
-			artifact="https://$bucket/builds/Linux/x86_64/docker-$fullVersion"
-			;;
-		*)
-			artifact="https://$bucket/builds/Linux/x86_64/docker-$fullVersion.tgz"
-			;;
-	esac
-	sha256="$(curl -fsSL "$artifact.sha256" | cut -d' ' -f1)" || true
-	(
-		set -x
-		sed -ri '
-			s/^(ENV DOCKER_BUCKET) .*/\1 '"$bucket"'/;
-			s/^(ENV DOCKER_VERSION) .*/\1 '"$fullVersion"'/;
-			s/^(ENV DOCKER_SHA256) .*/\1 '"$sha256"'/;
-			#s/^(ENV DIND_COMMIT) .*/\1 '"$dindLatest"'/; # TODO once "Supported Docker versions" minimums at Docker 1.8+ (1.6 at time of this writing), bring this back again
-			s/^(FROM docker):.*/\1:'"$version"'/;
-		' "$version/Dockerfile" "$version"/*/Dockerfile
-	)
-	
-	travisEnv='\n  - VERSION='"$version$travisEnv"
+	for variant in experimental ''; do
+		dir="$version${variant:+/$variant}"
+		[ -d "$dir" ] || continue
+
+		if [ "$variant" = 'experimental' ]; then
+			bucket='experimental.docker.com'
+		elif [ "$rcVersion" != "$version" ]; then
+			bucket='test.docker.com'
+		else
+			bucket='get.docker.com'
+		fi
+
+		artifact="https://$bucket/builds/Linux/x86_64/docker-$fullVersion.tgz"
+		sha256="$(curl -fsSL "$artifact.sha256" | cut -d' ' -f1)" || true
+
+		(
+			set -x
+			sed -ri '
+				s/^(ENV DOCKER_BUCKET) .*/\1 '"$bucket"'/;
+				s/^(ENV DOCKER_VERSION) .*/\1 '"$fullVersion"'/;
+				s/^(ENV DOCKER_SHA256) .*/\1 '"$sha256"'/;
+				#s/^(ENV DIND_COMMIT) .*/\1 '"$dindLatest"'/; # TODO once "Supported Docker versions" minimums at Docker 1.8+ (1.6 at time of this writing), bring this back again
+				s/^(FROM docker):.*/\1:'"$version${variant:+-$variant}"'/;
+			' "$dir"/{,git/,dind/}Dockerfile
+		)
+
+		travisEnv='\n  - VERSION='"$version VARIANT=$variant$travisEnv"
+	done
 done
 
 travis="$(awk -v 'RS=\n\n' '$1 == "env:" { $0 = "env:'"$travisEnv"'" } { printf "%s%s", $0, RS }' .travis.yml)"
```