### PR TITLE
Convert over to invoking "dockerd" directly instead of relying on the "docker daemon" translation

### DIFF
--- a/1.12/dind/dockerd-entrypoint.sh
+++ b/1.12/dind/dockerd-entrypoint.sh
@@ -5,14 +5,14 @@ set -e
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 -o "${1#-}" != "$1" ]; then
 	# add our default arguments
-	set -- docker daemon \
+	set -- dockerd \
 		--host=unix:///var/run/docker.sock \
 		--host=tcp://0.0.0.0:2375 \
 		--storage-driver=vfs \
 		"$@"
 fi
 
-if [ "$1" = 'docker' -a "$2" = 'daemon' ]; then
+if [ "$1" = 'dockerd' ]; then
 	# if we're running Docker, let's pipe through dind
 	# (and we'll run dind explicitly with "sh" since its shebang is /bin/bash)
 	set -- sh "$(which dind)" "$@"

--- a/1.12/experimental/dind/dockerd-entrypoint.sh
+++ b/1.12/experimental/dind/dockerd-entrypoint.sh
@@ -5,14 +5,14 @@ set -e
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 -o "${1#-}" != "$1" ]; then
 	# add our default arguments
-	set -- docker daemon \
+	set -- dockerd \
 		--host=unix:///var/run/docker.sock \
 		--host=tcp://0.0.0.0:2375 \
 		--storage-driver=vfs \
 		"$@"
 fi
 
-if [ "$1" = 'docker' -a "$2" = 'daemon' ]; then
+if [ "$1" = 'dockerd' ]; then
 	# if we're running Docker, let's pipe through dind
 	# (and we'll run dind explicitly with "sh" since its shebang is /bin/bash)
 	set -- sh "$(which dind)" "$@"

--- a/1.13-rc/dind/dockerd-entrypoint.sh
+++ b/1.13-rc/dind/dockerd-entrypoint.sh
@@ -5,14 +5,14 @@ set -e
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 -o "${1#-}" != "$1" ]; then
 	# add our default arguments
-	set -- docker daemon \
+	set -- dockerd \
 		--host=unix:///var/run/docker.sock \
 		--host=tcp://0.0.0.0:2375 \
 		--storage-driver=vfs \
 		"$@"
 fi
 
-if [ "$1" = 'docker' -a "$2" = 'daemon' ]; then
+if [ "$1" = 'dockerd' ]; then
 	# if we're running Docker, let's pipe through dind
 	# (and we'll run dind explicitly with "sh" since its shebang is /bin/bash)
 	set -- sh "$(which dind)" "$@"


### PR DESCRIPTION
This is going to be especially important for 1.13+ where `docker daemon` is now officially deprecated (and in at least `-rc1`, appears to have issues: https://github.com/docker/docker/issues/28368).