### PR TITLE
Change `foo --help` check to `help foo` in 1.13 entrypoint

### DIFF
--- a/1.11/docker-entrypoint.sh
+++ b/1.11/docker-entrypoint.sh
@@ -8,7 +8,7 @@ fi
 
 # if our command is a valid Docker subcommand, let's invoke it through Docker instead
 # (this allows for "docker run docker ps", etc)
-if docker "$1" --help > /dev/null 2>&1; then
+if docker help "$1" > /dev/null 2>&1; then
 	set -- docker "$@"
 fi
 

--- a/1.12/docker-entrypoint.sh
+++ b/1.12/docker-entrypoint.sh
@@ -8,7 +8,7 @@ fi
 
 # if our command is a valid Docker subcommand, let's invoke it through Docker instead
 # (this allows for "docker run docker ps", etc)
-if docker "$1" --help > /dev/null 2>&1; then
+if docker help "$1" > /dev/null 2>&1; then
 	set -- docker "$@"
 fi
 

--- a/1.13-rc/docker-entrypoint.sh
+++ b/1.13-rc/docker-entrypoint.sh
@@ -8,7 +8,7 @@ fi
 
 # if our command is a valid Docker subcommand, let's invoke it through Docker instead
 # (this allows for "docker run docker ps", etc)
-if docker "$1" --help > /dev/null 2>&1; then
+if docker help "$1" > /dev/null 2>&1; then
 	set -- docker "$@"
 fi
 


### PR DESCRIPTION
As per https://github.com/docker/docker/pull/28773 `docker foo --help` will no longer exit with status code 1 anymore, making the entrypoint think that *everything* is a valid docker subcommand.

Note that this will only work with 1.13-rc3 upwards, which is also why tests fail.