### PR TITLE
Revert Alpine 3.5 upgrade in 1.11 and 1.12 (leaving 1.13 on Alpine 3.5)

### DIFF
--- a/1.11/Dockerfile
+++ b/1.11/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.4
 
 RUN apk add --no-cache \
 		ca-certificates \

--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.4
 
 RUN apk add --no-cache \
 		ca-certificates \

--- a/1.12/experimental/Dockerfile
+++ b/1.12/experimental/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.4
 
 RUN apk add --no-cache \
 		ca-certificates \


### PR DESCRIPTION
Fixes #36

See https://github.com/docker-library/golang/pull/131#issuecomment-270677556 for further discussion.