### PR TITLE
Force cgo for golang DNS resolver

### DIFF
--- a/1.12/docker-entrypoint.sh
+++ b/1.12/docker-entrypoint.sh
@@ -12,6 +12,9 @@ if docker help "$1" > /dev/null 2>&1; then
 	set -- docker "$@"
 fi
 
+# force cgo resolver
+export GODEBUG=netdns=cgo
+
 # if we have "--link some-docker:docker" and not DOCKER_HOST, let's set DOCKER_HOST automatically
 if [ -z "$DOCKER_HOST" -a "$DOCKER_PORT_2375_TCP" ]; then
 	export DOCKER_HOST='tcp://docker:2375'

--- a/1.13/docker-entrypoint.sh
+++ b/1.13/docker-entrypoint.sh
@@ -12,6 +12,9 @@ if docker help "$1" > /dev/null 2>&1; then
 	set -- docker "$@"
 fi
 
+# force cgo resolver
+export GODEBUG=netdns=cgo
+
 # if we have "--link some-docker:docker" and not DOCKER_HOST, let's set DOCKER_HOST automatically
 if [ -z "$DOCKER_HOST" -a "$DOCKER_PORT_2375_TCP" ]; then
 	export DOCKER_HOST='tcp://docker:2375'


### PR DESCRIPTION
The default behavior of the golang net package is to use the pure go
implementation which sends DNS requests directly to the servers listed
in resolv.conf.  This breaks when running the docker client inside a
docker container that's 'linked' with other containers given that those
links utilize teh /etc/hosts to function.  This change forces golang's
netdns to use cgo which uses the system c libraries and respects
nsswitch.

Before this change any short name conflict will result in the DNS query
resolving to a remote host instead of the linked container.  For
example, docker will resolve to docker.rc.fas.harvard.edu instead of
the linked container due to the search domain in /etc/resolv.conf.