### PR TITLE
More small (/24 instead /16) CIDR subnet for dind entrypoint

### DIFF
--- a/17.03/dind/dockerd-entrypoint.sh
+++ b/17.03/dind/dockerd-entrypoint.sh
@@ -9,6 +9,7 @@ if [ "$#" -eq 0 -o "${1#-}" != "$1" ]; then
 		--host=unix:///var/run/docker.sock \
 		--host=tcp://0.0.0.0:2375 \
 		--storage-driver=vfs \
+        --bip=172.18.0.1/24 \
 		"$@"
 fi
 


### PR DESCRIPTION
Hi, I have wasted a lot of time because 172.18.0.0/16 is too broad and my internal network in this range. 
