### PR TITLE
Add experimental armhf support via "case" on "apk --print-arch"

### DIFF
--- a/17.03/Dockerfile
+++ b/17.03/Dockerfile
@@ -7,16 +7,25 @@ RUN apk add --no-cache \
 
 ENV DOCKER_BUCKET get.docker.com
 ENV DOCKER_VERSION 17.03.1-ce
-ENV DOCKER_SHA256 820d13b5699b5df63f7032c8517a5f118a44e2be548dd03271a86656a544af55
+ENV DOCKER_SHA256_x86_64 820d13b5699b5df63f7032c8517a5f118a44e2be548dd03271a86656a544af55
+ENV DOCKER_SHA256_armel f05c733c22915b0c26d8b0390b26a026b33aaf7593d15475a6f86e1bbe1ddbe2
 
-RUN set -x \
-	&& curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
-	&& echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
-	&& tar -xzvf docker.tgz \
-	&& mv docker/* /usr/local/bin/ \
-	&& rmdir docker \
-	&& rm docker.tgz \
-	&& docker -v
+RUN set -ex; \
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		x86_64) dockerArch=x86_64 ;; \
+		armhf) dockerArch=armel ;; \
+		*) echo >&2 "error: unknown Docker static binary arch $apkArch"; exit 1 ;; \
+	esac; \
+	curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/${dockerArch}/docker-${DOCKER_VERSION}.tgz" -o docker.tgz; \
+# /bin/sh doesn't support ${!...} :(
+	sha256="DOCKER_SHA256_${dockerArch}"; sha256="$(eval "echo \$${sha256}")"; \
+	echo "${sha256} *docker.tgz" | sha256sum -c -; \
+	tar -xzvf docker.tgz; \
+	mv docker/* /usr/local/bin/; \
+	rmdir docker; \
+	rm docker.tgz; \
+	docker -v
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/17.04/Dockerfile
+++ b/17.04/Dockerfile
@@ -7,16 +7,25 @@ RUN apk add --no-cache \
 
 ENV DOCKER_BUCKET get.docker.com
 ENV DOCKER_VERSION 17.04.0-ce
-ENV DOCKER_SHA256 c52cff62c4368a978b52e3d03819054d87bcd00d15514934ce2e0e09b99dd100
+ENV DOCKER_SHA256_x86_64 c52cff62c4368a978b52e3d03819054d87bcd00d15514934ce2e0e09b99dd100
+ENV DOCKER_SHA256_armel 9b7df7dc02f620748657d3f599a9701c35f7b0b3d0acbc7fd324126ba5f6c4e9
 
-RUN set -x \
-	&& curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
-	&& echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
-	&& tar -xzvf docker.tgz \
-	&& mv docker/* /usr/local/bin/ \
-	&& rmdir docker \
-	&& rm docker.tgz \
-	&& docker -v
+RUN set -ex; \
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		x86_64) dockerArch=x86_64 ;; \
+		armhf) dockerArch=armel ;; \
+		*) echo >&2 "error: unknown Docker static binary arch $apkArch"; exit 1 ;; \
+	esac; \
+	curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/${dockerArch}/docker-${DOCKER_VERSION}.tgz" -o docker.tgz; \
+# /bin/sh doesn't support ${!...} :(
+	sha256="DOCKER_SHA256_${dockerArch}"; sha256="$(eval "echo \$${sha256}")"; \
+	echo "${sha256} *docker.tgz" | sha256sum -c -; \
+	tar -xzvf docker.tgz; \
+	mv docker/* /usr/local/bin/; \
+	rmdir docker; \
+	rm docker.tgz; \
+	docker -v
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/17.05-rc/Dockerfile
+++ b/17.05-rc/Dockerfile
@@ -7,16 +7,25 @@ RUN apk add --no-cache \
 
 ENV DOCKER_BUCKET test.docker.com
 ENV DOCKER_VERSION 17.05.0-ce-rc1
-ENV DOCKER_SHA256 4561742c2174c01ffd0679621b66d29f8a504240d79aa714f6c58348979d02c6
+ENV DOCKER_SHA256_x86_64 4561742c2174c01ffd0679621b66d29f8a504240d79aa714f6c58348979d02c6
+ENV DOCKER_SHA256_armel 55da582c59e2f2ccebf74c661290ecdc4d503b53acff1644a85f1c1d60dfd661
 
-RUN set -x \
-	&& curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz \
-	&& echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
-	&& tar -xzvf docker.tgz \
-	&& mv docker/* /usr/local/bin/ \
-	&& rmdir docker \
-	&& rm docker.tgz \
-	&& docker -v
+RUN set -ex; \
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		x86_64) dockerArch=x86_64 ;; \
+		armhf) dockerArch=armel ;; \
+		*) echo >&2 "error: unknown Docker static binary arch $apkArch"; exit 1 ;; \
+	esac; \
+	curl -fSL "https://${DOCKER_BUCKET}/builds/Linux/${dockerArch}/docker-${DOCKER_VERSION}.tgz" -o docker.tgz; \
+# /bin/sh doesn't support ${!...} :(
+	sha256="DOCKER_SHA256_${dockerArch}"; sha256="$(eval "echo \$${sha256}")"; \
+	echo "${sha256} *docker.tgz" | sha256sum -c -; \
+	tar -xzvf docker.tgz; \
+	mv docker/* /usr/local/bin/; \
+	rmdir docker; \
+	rm docker.tgz; \
+	docker -v
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/update.sh
+++ b/update.sh
@@ -36,19 +36,27 @@ for version in "${versions[@]}"; do
 		bucket='get.docker.com'
 	fi
 
-	artifact="https://$bucket/builds/Linux/x86_64/docker-$fullVersion.tgz"
-	sha256="$(curl -fsSL "$artifact.sha256" | cut -d' ' -f1)" || true
-
 	(
 		set -x
-		sed -ri '
-			s/^(ENV DOCKER_BUCKET) .*/\1 '"$bucket"'/;
-			s/^(ENV DOCKER_VERSION) .*/\1 '"$fullVersion"'/;
-			s/^(ENV DOCKER_SHA256) .*/\1 '"$sha256"'/;
-			#s/^(ENV DIND_COMMIT) .*/\1 '"$dindLatest"'/; # TODO once "Supported Docker versions" minimums at Docker 1.8+ (1.6 at time of this writing), bring this back again
-			s/^(FROM docker):.*/\1:'"$version"'/;
-		' "$dir"/{,git/,dind/}Dockerfile
+		#s/^(ENV DIND_COMMIT) .*/\1 '"$dindLatest"'/; # TODO once "Supported Docker versions" minimums at Docker 1.8+ (1.6 at time of this writing), bring this back again
+		sed -ri \
+			-e 's/^(ENV DOCKER_BUCKET) .*/\1 '"$bucket"'/' \
+			-e 's/^(ENV DOCKER_VERSION) .*/\1 '"$fullVersion"'/' \
+			-e 's/^(FROM docker):.*/\1:'"$version"'/' \
+			"$dir"/{,git/,dind/}Dockerfile
 	)
+
+	for arch in \
+		x86_64 \
+		armel \
+	; do
+		url="https://$bucket/builds/Linux/$arch/docker-$fullVersion.tgz.sha256"
+		sha256="$(curl -fsSL "$url" | cut -d' ' -f1)"
+		(
+			set -x
+			sed -ri 's!^(ENV DOCKER_SHA256_'"$arch"') .*!\1 '"$sha256"'!' "$dir/Dockerfile"
+		)
+	done
 
 	travisEnv='\n  - VERSION='"$version$travisEnv"
 done


### PR DESCRIPTION
This allows for the same source to build on both amd64 and armhf -- I'm not 100% sure whether Docker's static binary releases are ARMv6 or ARMv7, and I've only got an ARMv7 environment to test in. :innocent:

Here's some `docker version` and `docker info` output from a running instance of this DinD on an ARM machine:
```console
$ docker -H tcp://172.17.0.2:2375 version
Client:
 Version:      1.12.6
 API version:  1.24
 Go version:   go1.6.2
 Git commit:   78d1802
 Built:        Tue Jan 31 23:35:09 2017
 OS/Arch:      linux/arm

Server:
 Version:      17.03.1-ce
 API version:  1.27
 Go version:   go1.7.5
 Git commit:   c6d412e
 Built:        Tue Mar 28 03:25:54 2017
 OS/Arch:      linux/arm
$ docker -H tcp://172.17.0.2:2375 info
Containers: 0
 Running: 0
 Paused: 0
 Stopped: 0
Images: 0
Server Version: 17.03.1-ce
Storage Driver: aufs
 Root Dir: /var/lib/docker/aufs
 Backing Filesystem: extfs
 Dirs: 0
 Dirperm1 Supported: true
Logging Driver: json-file
Cgroup Driver: cgroupfs
Plugins:
 Volume: local
 Network: bridge host macvlan null overlay
Swarm: inactive
Runtimes: runc
Default Runtime: runc
Security Options: apparmor seccomp
Kernel Version: 4.4.0-1040-raspi2
Operating System: Alpine Linux v3.5 (containerized)
OSType: linux
Architecture: armv7l
CPUs: 4
Total Memory: 729.7 MiB
Name: be2cc3b1a5d0
ID: GCV6:KPUT:HA7C:GRHD:63ZJ:L6KR:F6YW:24OQ:I2ME:W6MY:RRXT:WGLY
Docker Root Dir: /var/lib/docker
Debug Mode (client): false
Debug Mode (server): false
Registry: https://index.docker.io/v1/
WARNING: No cpuset support
WARNING: bridge-nf-call-iptables is disabled
WARNING: bridge-nf-call-ip6tables is disabled
Insecure Registries:
 127.0.0.0/8
```