### PR TITLE
Allow dind images to include parameters in env variables

### DIFF
--- a/17.06-rc/dind/dockerd-entrypoint.sh
+++ b/17.06-rc/dind/dockerd-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+DOCKER_OPTS=${DOCKER_OPTS:-}
+
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 -o "${1#-}" != "$1" ]; then
@@ -9,6 +11,7 @@ if [ "$#" -eq 0 -o "${1#-}" != "$1" ]; then
 		--host=unix:///var/run/docker.sock \
 		--host=tcp://0.0.0.0:2375 \
 		--storage-driver=vfs \
+		${DOCKER_OPTS} \
 		"$@"
 fi
 


### PR DESCRIPTION
This may enhance the user experience when using dind as part of a
Continuous Integration environment.