### PR TITLE
Add a little "paperclip" suggestion when attempting to run "dockerd" in the non-dind image variants

### DIFF
--- a/17.03-rc/docker-entrypoint.sh
+++ b/17.03-rc/docker-entrypoint.sh
@@ -17,4 +17,19 @@ if [ -z "$DOCKER_HOST" -a "$DOCKER_PORT_2375_TCP" ]; then
 	export DOCKER_HOST='tcp://docker:2375'
 fi
 
+if [ "$1" = 'dockerd' ]; then
+	cat >&2 <<-'EOW'
+
+		📎 Hey there!  It looks like you're trying to run a Docker daemon.
+
+		   You probably should use the "dind" image variant instead, something like:
+
+		     docker run --privileged --name some-overlay-docker -d docker:stable-dind --storage-driver=overlay
+
+		   See https://hub.docker.com/_/docker/ for more documentation and usage examples.
+
+	EOW
+	sleep 3
+fi
+
 exec "$@"

--- a/17.03/docker-entrypoint.sh
+++ b/17.03/docker-entrypoint.sh
@@ -17,4 +17,19 @@ if [ -z "$DOCKER_HOST" -a "$DOCKER_PORT_2375_TCP" ]; then
 	export DOCKER_HOST='tcp://docker:2375'
 fi
 
+if [ "$1" = 'dockerd' ]; then
+	cat >&2 <<-'EOW'
+
+		📎 Hey there!  It looks like you're trying to run a Docker daemon.
+
+		   You probably should use the "dind" image variant instead, something like:
+
+		     docker run --privileged --name some-overlay-docker -d docker:stable-dind --storage-driver=overlay
+
+		   See https://hub.docker.com/_/docker/ for more documentation and usage examples.
+
+	EOW
+	sleep 3
+fi
+
 exec "$@"

--- a/17.05/docker-entrypoint.sh
+++ b/17.05/docker-entrypoint.sh
@@ -17,4 +17,19 @@ if [ -z "$DOCKER_HOST" -a "$DOCKER_PORT_2375_TCP" ]; then
 	export DOCKER_HOST='tcp://docker:2375'
 fi
 
+if [ "$1" = 'dockerd' ]; then
+	cat >&2 <<-'EOW'
+
+		📎 Hey there!  It looks like you're trying to run a Docker daemon.
+
+		   You probably should use the "dind" image variant instead, something like:
+
+		     docker run --privileged --name some-overlay-docker -d docker:stable-dind --storage-driver=overlay
+
+		   See https://hub.docker.com/_/docker/ for more documentation and usage examples.
+
+	EOW
+	sleep 3
+fi
+
 exec "$@"

--- a/17.06-rc/docker-entrypoint.sh
+++ b/17.06-rc/docker-entrypoint.sh
@@ -17,4 +17,19 @@ if [ -z "$DOCKER_HOST" -a "$DOCKER_PORT_2375_TCP" ]; then
 	export DOCKER_HOST='tcp://docker:2375'
 fi
 
+if [ "$1" = 'dockerd' ]; then
+	cat >&2 <<-'EOW'
+
+		📎 Hey there!  It looks like you're trying to run a Docker daemon.
+
+		   You probably should use the "dind" image variant instead, something like:
+
+		     docker run --privileged --name some-overlay-docker -d docker:stable-dind --storage-driver=overlay
+
+		   See https://hub.docker.com/_/docker/ for more documentation and usage examples.
+
+	EOW
+	sleep 3
+fi
+
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,4 +17,19 @@ if [ -z "$DOCKER_HOST" -a "$DOCKER_PORT_2375_TCP" ]; then
 	export DOCKER_HOST='tcp://docker:2375'
 fi
 
+if [ "$1" = 'dockerd' ]; then
+	cat >&2 <<-'EOW'
+
+		📎 Hey there!  It looks like you're trying to run a Docker daemon.
+
+		   You probably should use the "dind" image variant instead, something like:
+
+		     docker run --privileged --name some-overlay-docker -d docker:stable-dind --storage-driver=overlay
+
+		   See https://hub.docker.com/_/docker/ for more documentation and usage examples.
+
+	EOW
+	sleep 3
+fi
+
 exec "$@"


### PR DESCRIPTION
Fixes #61

Here's the example output:
```console
$ docker run -it --rm docker:17.06-rc dockerd

📎 Hey there!  It looks like you're trying to run a Docker daemon.

   You probably should use the "dind" image variant instead, something like:

     docker run --privileged --name some-overlay-docker -d docker:stable-dind --storage-driver=overlay

   See https://hub.docker.com/_/docker/ for more documentation and usage examples.

WARN[0000] could not change group /var/run/docker.sock to docker: group docker not found
...
```