### PR TITLE
dind: add git to the dind image

### DIFF
--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -5,6 +5,7 @@ RUN apk add --no-cache \
 		btrfs-progs \
 		e2fsprogs \
 		e2fsprogs-extra \
+		git \
 		iptables \
 		xfsprogs \
 		xz


### PR DESCRIPTION
Docker will shell out to `git` if it receives a request like:

```
$ curl  -d "" http://localhost:2375/v1.22/build?remote=https%3A%2F%2Fgithub.com%2Fdnephin%2Fdocker-build-from-url.git
failed to init repo at /var/lib/docker/tmp/docker-build-git645459714: : exec: "git": executable file not found in $PATH
```

or via a compose file:
```
$ cat > docker-compose.yml <<EOT
version: '2'

services:
  test:
    build: "https://github.com/dnephin/docker-build-from-url.git"
EOT

$ docker-compose build
```
This patch attempts to add git to the dind image to fix these cases.

I modified the file marked `.template` but I don't know how/if the other files should be updated. I've not tested a build from this repo, but I tested a very similar patch in [linuxkit/linuxkit#2201]

(It's a shame to make the image bigger.)

## References

- original discussion over on https://github.com/linuxkit/linuxkit/pull/2201
- [builder/remotecontext/git/gitutils.go](https://github.com/moby/moby/blob/72959fc2161fdcd785ad54a38cd03049250236fb/builder/remotecontext/git/gitutils.go#L152) which shells out to `git` (thanks to @ijc for pointing me at this)
