### PR TITLE
Add zfs progs to :dind images

### DIFF
--- a/17.06/dind/Dockerfile
+++ b/17.06/dind/Dockerfile
@@ -7,7 +7,8 @@ RUN apk add --no-cache \
 		e2fsprogs-extra \
 		iptables \
 		xfsprogs \
-		xz
+		xz \
+		zfs
 
 # TODO aufs-tools
 

--- a/17.09/dind/Dockerfile
+++ b/17.09/dind/Dockerfile
@@ -7,7 +7,8 @@ RUN apk add --no-cache \
 		e2fsprogs-extra \
 		iptables \
 		xfsprogs \
-		xz
+		xz \
+		zfs
 
 # TODO aufs-tools
 

--- a/17.10/dind/Dockerfile
+++ b/17.10/dind/Dockerfile
@@ -7,7 +7,8 @@ RUN apk add --no-cache \
 		e2fsprogs-extra \
 		iptables \
 		xfsprogs \
-		xz
+		xz \
+		zfs
 
 # TODO aufs-tools
 

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -7,7 +7,8 @@ RUN apk add --no-cache \
 		e2fsprogs-extra \
 		iptables \
 		xfsprogs \
-		xz
+		xz \
+		zfs
 
 # TODO aufs-tools
 


### PR DESCRIPTION
Like it says on the tin. Without the zfs binaries included, the `:dind` images fail when Docker uses the zfs graph driver. If there are compatibility issues with adding the zfs package to every image, please let me know.

Here is what I have to do to get GitLab CI to work with Docker and the zfs graph driver.

1. Create a custom `:dind` image:

https://gitlab.frielforreal.com/global/docker/blob/master/dind/Dockerfile:
```dockerfile
FROM docker:dind

RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
	zfs

COPY dind-entrypoint.sh /usr/local/bin/

ENTRYPOINT ["dind-entrypoint.sh"]
CMD []
```

2. Modify `.gitlab-ci.yml` to use the above images instead of `docker:dind` and alias it to ` docker`:

https://gitlab.frielforreal.com/global/docker/blob/master/.gitlab-ci.yml
```yaml
image: docker:latest

services:
  - name: registry.gitlab.frielforreal.com/global/docker:dind
    alias: docker


# ...
```
