### PR TITLE
Remove vfs as default storage driver.

### DIFF
--- a/17.06/dind/dockerd-entrypoint.sh
+++ b/17.06/dind/dockerd-entrypoint.sh
@@ -8,7 +8,6 @@ if [ "$#" -eq 0 -o "${1#-}" != "$1" ]; then
 	set -- dockerd \
 		--host=unix:///var/run/docker.sock \
 		--host=tcp://0.0.0.0:2375 \
-		--storage-driver=vfs \
 		"$@"
 fi
 

--- a/17.09/dind/dockerd-entrypoint.sh
+++ b/17.09/dind/dockerd-entrypoint.sh
@@ -8,7 +8,6 @@ if [ "$#" -eq 0 -o "${1#-}" != "$1" ]; then
 	set -- dockerd \
 		--host=unix:///var/run/docker.sock \
 		--host=tcp://0.0.0.0:2375 \
-		--storage-driver=vfs \
 		"$@"
 fi
 

--- a/17.10/dind/dockerd-entrypoint.sh
+++ b/17.10/dind/dockerd-entrypoint.sh
@@ -8,7 +8,6 @@ if [ "$#" -eq 0 -o "${1#-}" != "$1" ]; then
 	set -- dockerd \
 		--host=unix:///var/run/docker.sock \
 		--host=tcp://0.0.0.0:2375 \
-		--storage-driver=vfs \
 		"$@"
 fi
 

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -8,7 +8,6 @@ if [ "$#" -eq 0 -o "${1#-}" != "$1" ]; then
 	set -- dockerd \
 		--host=unix:///var/run/docker.sock \
 		--host=tcp://0.0.0.0:2375 \
-		--storage-driver=vfs \
 		"$@"
 fi
 


### PR DESCRIPTION
This is a follow-on of #88. The vfs storage driver is no longer defaulted to, as Docker now has more sensible defaults than it did when device mapper was used. Years ago, Docker defaulted to the devicemapper storage driver, which had issues reclaiming space and filling disks (see: moby/moby/issues/3182). I believe the reason the Docker in Docker (`dind`) image defaulted to the vfs storage driver was to avoid that issue.

Fortunately, since I created moby/moby/issues/3182, Docker now defaults to more flexible storage drivers such as overlay2, zfs, and btrfs, and the `dind` image no longer needs to default to vfs.

This PR will improve performance of Docker in Docker images running on any of the aforementioned storage drivers.