### PR TITLE
Add pigz binary for upcoming Docker 18.02 release

### DIFF
--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -9,6 +9,8 @@ RUN set -eux; \
 		iptables \
 		xfsprogs \
 		xz \
+# pigz: https://github.com/moby/moby/pull/35697 (faster gzip implementation)
+		pigz \
 	; \
 # only install zfs if it's available for the current architecture
 # https://git.alpinelinux.org/cgit/aports/tree/main/zfs/APKBUILD?h=3.6-stable#n9 ("all !armhf !ppc64le" as of 2017-11-01)

--- a/update.sh
+++ b/update.sh
@@ -72,6 +72,11 @@ for version in "${versions[@]}"; do
 
 	alpine="${alpineVersion[$version]:-$defaultAlpineVersion}"
 
+	majorVersion="${fullVersion%%.*}"
+	minorVersion="${fullVersion#$majorVersion.}"
+	minorVersion="${minorVersion%%.*}"
+	minorVersion="${minorVersion#0}"
+
 	for variant in \
 		'' git dind \
 		windows/windowsservercore-{1709,ltsc2016} \
@@ -91,6 +96,11 @@ for version in "${versions[@]}"; do
 			-e 's!%%TAG%%!'"$tag"'!g' \
 			-e 's!%%ARCH-CASE%%!'"$(sed_escape_rhs "$archCase")"'!g' \
 			"$template" > "$df"
+
+		# pigz (https://github.com/moby/moby/pull/35697) is only 18.02+
+		if [ "$majorVersion" -lt 18 ] || { [ "$majorVersion" -eq 18 ] && [ "$minorVersion" -lt 2 ]; }; then
+			sed -ri '/pigz/d' "$df"
+		fi
 
 		if [[ "$variant" == windows/* ]]; then
 			winVariant="$(basename "$variant")"


### PR DESCRIPTION
Docker 18.02 will us parallel decompression of images after pulling, but relies on the `pigz` binary to be present.

This patch adds the pigz binary :)


relates to https://github.com/moby/moby/pull/35697