### PR TITLE
Explicitly remove "/var/run/docker.pid" at container startup (in case Docker didn't stop cleanly)

### DIFF
--- a/17.12/dind/dockerd-entrypoint.sh
+++ b/17.12/dind/dockerd-entrypoint.sh
@@ -15,6 +15,9 @@ if [ "$1" = 'dockerd' ]; then
 	# if we're running Docker, let's pipe through dind
 	# (and we'll run dind explicitly with "sh" since its shebang is /bin/bash)
 	set -- sh "$(which dind)" "$@"
+
+	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
+	rm -f /var/run/docker.pid
 fi
 
 exec "$@"

--- a/18.03/dind/dockerd-entrypoint.sh
+++ b/18.03/dind/dockerd-entrypoint.sh
@@ -15,6 +15,9 @@ if [ "$1" = 'dockerd' ]; then
 	# if we're running Docker, let's pipe through dind
 	# (and we'll run dind explicitly with "sh" since its shebang is /bin/bash)
 	set -- sh "$(which dind)" "$@"
+
+	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
+	rm -f /var/run/docker.pid
 fi
 
 exec "$@"

--- a/18.04-rc/dind/dockerd-entrypoint.sh
+++ b/18.04-rc/dind/dockerd-entrypoint.sh
@@ -15,6 +15,9 @@ if [ "$1" = 'dockerd' ]; then
 	# if we're running Docker, let's pipe through dind
 	# (and we'll run dind explicitly with "sh" since its shebang is /bin/bash)
 	set -- sh "$(which dind)" "$@"
+
+	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
+	rm -f /var/run/docker.pid
 fi
 
 exec "$@"

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -15,6 +15,9 @@ if [ "$1" = 'dockerd' ]; then
 	# if we're running Docker, let's pipe through dind
 	# (and we'll run dind explicitly with "sh" since its shebang is /bin/bash)
 	set -- sh "$(which dind)" "$@"
+
+	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
+	rm -f /var/run/docker.pid
 fi
 
 exec "$@"


### PR DESCRIPTION
Fixes #104