### PR TITLE
Finally update "dind" wrapper to the latest commit

### DIFF
--- a/17.12/dind/Dockerfile
+++ b/17.12/dind/Dockerfile
@@ -26,7 +26,8 @@ RUN set -x \
 	&& echo 'dockremap:165536:65536' >> /etc/subuid \
 	&& echo 'dockremap:165536:65536' >> /etc/subgid
 
-ENV DIND_COMMIT 3b5fac462d21ca164b3778647420016315289034
+# https://github.com/docker/docker/tree/master/hack/dind
+ENV DIND_COMMIT 52379fa76dee07ca038624d639d9e14f4fb719ff
 
 RUN set -ex; \
 	apk add --no-cache --virtual .fetch-deps libressl; \

--- a/18.03/dind/Dockerfile
+++ b/18.03/dind/Dockerfile
@@ -28,7 +28,8 @@ RUN set -x \
 	&& echo 'dockremap:165536:65536' >> /etc/subuid \
 	&& echo 'dockremap:165536:65536' >> /etc/subgid
 
-ENV DIND_COMMIT 3b5fac462d21ca164b3778647420016315289034
+# https://github.com/docker/docker/tree/master/hack/dind
+ENV DIND_COMMIT 52379fa76dee07ca038624d639d9e14f4fb719ff
 
 RUN set -ex; \
 	apk add --no-cache --virtual .fetch-deps libressl; \

--- a/18.04/dind/Dockerfile
+++ b/18.04/dind/Dockerfile
@@ -28,7 +28,8 @@ RUN set -x \
 	&& echo 'dockremap:165536:65536' >> /etc/subuid \
 	&& echo 'dockremap:165536:65536' >> /etc/subgid
 
-ENV DIND_COMMIT 3b5fac462d21ca164b3778647420016315289034
+# https://github.com/docker/docker/tree/master/hack/dind
+ENV DIND_COMMIT 52379fa76dee07ca038624d639d9e14f4fb719ff
 
 RUN set -ex; \
 	apk add --no-cache --virtual .fetch-deps libressl; \

--- a/18.05-rc/dind/Dockerfile
+++ b/18.05-rc/dind/Dockerfile
@@ -28,7 +28,8 @@ RUN set -x \
 	&& echo 'dockremap:165536:65536' >> /etc/subuid \
 	&& echo 'dockremap:165536:65536' >> /etc/subgid
 
-ENV DIND_COMMIT 3b5fac462d21ca164b3778647420016315289034
+# https://github.com/docker/docker/tree/master/hack/dind
+ENV DIND_COMMIT 52379fa76dee07ca038624d639d9e14f4fb719ff
 
 RUN set -ex; \
 	apk add --no-cache --virtual .fetch-deps libressl; \

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -28,7 +28,8 @@ RUN set -x \
 	&& echo 'dockremap:165536:65536' >> /etc/subuid \
 	&& echo 'dockremap:165536:65536' >> /etc/subgid
 
-ENV DIND_COMMIT 3b5fac462d21ca164b3778647420016315289034
+# https://github.com/docker/docker/tree/master/hack/dind
+ENV DIND_COMMIT %%DIND-COMMIT%%
 
 RUN set -ex; \
 	apk add --no-cache --virtual .fetch-deps libressl; \

--- a/update.sh
+++ b/update.sh
@@ -27,9 +27,6 @@ sed_escape_rhs() {
 # "tac|tac" for http://stackoverflow.com/a/28879552/433558
 dindLatest="$(curl -fsSL 'https://github.com/docker/docker/commits/master/hack/dind.atom' | tac|tac | awk -F '[[:space:]]*[<>/]+' '$2 == "id" && $3 ~ /Commit/ { print $4; exit }')"
 
-# TODO once "Supported Docker versions" minimums at Docker 1.8+ (1.6 at time of this writing), bring this back again
-#sed -r -e 's/^(ENV DIND_COMMIT) .*/\1 '"$dindLatest"'/' Dockerfile-dind.template
-
 dockerVersions="$(
 	{
 		git ls-remote --tags https://github.com/docker/docker-ce.git
@@ -94,6 +91,7 @@ for version in "${versions[@]}"; do
 			-e 's!%%DOCKER-CHANNEL%%!'"$channel"'!g' \
 			-e 's!%%DOCKER-VERSION%%!'"$fullVersion"'!g' \
 			-e 's!%%TAG%%!'"$tag"'!g' \
+			-e 's!%%DIND-COMMIT%%!'"$dindLatest"'!g' \
 			-e 's!%%ARCH-CASE%%!'"$(sed_escape_rhs "$archCase")"'!g' \
 			"$template" > "$df"
 


### PR DESCRIPTION
Users on versions older than 1.8 should probably upgrade at this point.

Using something like `-v /sys/fs/cgroup:/sys/fs/cgroup` on 1.6 and 1.7 is probably the only workaround to this update.

For reference:

```diff
$ GIT_PAGER=cat git diff 3b5fac462d21ca164b3778647420016315289034...52379fa76dee07ca038624d639d9e14f4fb719ff -- hack/dind
diff --git a/hack/dind b/hack/dind
index a8c09283f6..3254f9dbe7 100755
--- a/hack/dind
+++ b/hack/dind
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e

 # DinD: a wrapper script which allows docker to be run inside a docker container.
 # Original version by Jerome Petazzoni <jerome@docker.com>
 # See the blog post: https://blog.docker.com/2013/09/docker-can-now-run-within-docker/
 #
-# This script should be executed inside a docker container in privilieged mode
+# This script should be executed inside a docker container in privileged mode
 # ('docker run --privileged', introduced in docker 0.6).

 # Usage: dind CMD [ARG...]
@@ -13,74 +13,6 @@ set -e
 # apparmor sucks and Docker needs to know that it's in a container (c) @tianon
 export container=docker

-# as of docker 1.8, cgroups will be mounted in the container
-if ! mountpoint -q /sys/fs/cgroup; then
-
-	# First, make sure that cgroups are mounted correctly.
-	CGROUP=/cgroup
-
-	mkdir -p "$CGROUP"
-
-	if ! mountpoint -q "$CGROUP"; then
-		mount -n -t tmpfs -o uid=0,gid=0,mode=0755 cgroup $CGROUP || {
-			echo >&2 'Could not make a tmpfs mount. Did you use --privileged?'
-			exit 1
-		}
-	fi
-
-	# Mount the cgroup hierarchies exactly as they are in the parent system.
-	for HIER in $(cut -d: -f2 /proc/1/cgroup); do
-
-		SUBSYSTEMS="${HIER%name=*}"
-
-		# If cgroup hierarchy is named(mounted with "-o name=foo") we
-		# need to mount it in $CGROUP/foo to create exect same
-		# directoryes as on host. Else we need to mount it as is e.g.
-		# "subsys1,subsys2" if it has two subsystems
-
-		# Named, control-less cgroups are mounted with "-o name=foo"
-		# (and appear as such under /proc/<pid>/cgroup) but are usually
-		# mounted on a directory named "foo" (without the "name=" prefix).
-		# Systemd and OpenRC (and possibly others) both create such a
-		# cgroup. So just mount them on directory $CGROUP/foo.
-
-		OHIER=$HIER
-		HIER="${HIER#*name=}"
-
-		mkdir -p "$CGROUP/$HIER"
-
-		if ! mountpoint -q "$CGROUP/$HIER"; then
-			mount -n -t cgroup -o "$OHIER" cgroup "$CGROUP/$HIER"
-		fi
-
-		# Likewise, on at least one system, it has been reported that
-		# systemd would mount the CPU and CPU accounting controllers
-		# (respectively "cpu" and "cpuacct") with "-o cpuacct,cpu"
-		# but on a directory called "cpu,cpuacct" (note the inversion
-		# in the order of the groups). This tries to work around it.
-
-		if [ "$HIER" = 'cpuacct,cpu' ]; then
-			ln -s "$HIER" "$CGROUP/cpu,cpuacct"
-		fi
-
-		# If hierarchy has multiple subsystems, in /proc/<pid>/cgroup
-		# we will see ":subsys1,subsys2,subsys3,name=foo:" substring,
-		# we need to mount it to "$CGROUP/foo" and if there were no
-		# name to "$CGROUP/subsys1,subsys2,subsys3", so we must create
-		# symlinks for docker daemon to find these subsystems:
-		# ln -s $CGROUP/foo $CGROUP/subsys1
-		# ln -s $CGROUP/subsys1,subsys2,subsys3 $CGROUP/subsys1
-
-		if [ "$SUBSYSTEMS" != "${SUBSYSTEMS//,/ }" ]; then
-			SUBSYSTEMS="${SUBSYSTEMS//,/ }"
-			for SUBSYS in $SUBSYSTEMS
-			do
-				ln -s "$CGROUP/$HIER" "$CGROUP/$SUBSYS"
-			done
-		fi
-	done
-fi
-
 if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
 	mount -t securityfs none /sys/kernel/security || {
 		echo >&2 'Could not mount /sys/kernel/security.'
@@ -88,16 +20,6 @@ if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
 	}
 fi

-# Note: as I write those lines, the LXC userland tools cannot setup
-# a "sub-container" properly if the "devices" cgroup is not in its
-# own hierarchy. Let's detect this and issue a warning.
-if ! grep -q :devices: /proc/1/cgroup; then
-	echo >&2 'WARNING: the "devices" cgroup should be in its own hierarchy.'
-fi
-if ! grep -qw devices /proc/1/cgroup; then
-	echo >&2 'WARNING: it looks like the "devices" cgroup is not mounted.'
-fi
-
 # Mount /tmp (conditionally)
 if ! mountpoint -q /tmp; then
 	mount -t tmpfs none /tmp
```