### PR TITLE
Update pid deletion code to also delete "docker-containerd.pid"

### DIFF
--- a/18.03/dind/dockerd-entrypoint.sh
+++ b/18.03/dind/dockerd-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 # no arguments passed
 # or first arg is `-f` or `--some-option`
-if [ "$#" -eq 0 -o "${1#-}" != "$1" ]; then
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
 	set -- dockerd \
 		--host=unix:///var/run/docker.sock \
@@ -17,7 +17,7 @@ if [ "$1" = 'dockerd' ]; then
 	set -- sh "$(which dind)" "$@"
 
 	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
-	rm -f /var/run/docker.pid
+	find /run /var/run -iname 'docker*.pid' -delete
 fi
 
 exec "$@"

--- a/18.05/dind/dockerd-entrypoint.sh
+++ b/18.05/dind/dockerd-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 # no arguments passed
 # or first arg is `-f` or `--some-option`
-if [ "$#" -eq 0 -o "${1#-}" != "$1" ]; then
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
 	set -- dockerd \
 		--host=unix:///var/run/docker.sock \
@@ -17,7 +17,7 @@ if [ "$1" = 'dockerd' ]; then
 	set -- sh "$(which dind)" "$@"
 
 	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
-	rm -f /var/run/docker.pid
+	find /run /var/run -iname 'docker*.pid' -delete
 fi
 
 exec "$@"

--- a/18.06-rc/dind/dockerd-entrypoint.sh
+++ b/18.06-rc/dind/dockerd-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 # no arguments passed
 # or first arg is `-f` or `--some-option`
-if [ "$#" -eq 0 -o "${1#-}" != "$1" ]; then
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
 	set -- dockerd \
 		--host=unix:///var/run/docker.sock \
@@ -17,7 +17,7 @@ if [ "$1" = 'dockerd' ]; then
 	set -- sh "$(which dind)" "$@"
 
 	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
-	rm -f /var/run/docker.pid
+	find /run /var/run -iname 'docker*.pid' -delete
 fi
 
 exec "$@"

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 # no arguments passed
 # or first arg is `-f` or `--some-option`
-if [ "$#" -eq 0 -o "${1#-}" != "$1" ]; then
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
 	set -- dockerd \
 		--host=unix:///var/run/docker.sock \
@@ -17,7 +17,7 @@ if [ "$1" = 'dockerd' ]; then
 	set -- sh "$(which dind)" "$@"
 
 	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
-	rm -f /var/run/docker.pid
+	find /run /var/run -iname 'docker*.pid' -delete
 fi
 
 exec "$@"


### PR DESCRIPTION
This is the root behind the system failure which caused https://github.com/gliderlabs/docker-alpine/issues/418#issuecomment-403054625.