### PR TITLE
Switch back to built-in "wget" (which works now!)

### DIFF
--- a/18.06/Dockerfile
+++ b/18.06/Dockerfile
@@ -15,15 +15,7 @@ ENV DOCKER_VERSION 18.06.1-ce
 # https://github.com/docker/docker-ce/blob/5b073ee2cf564edee5adca05eee574142f7627bb/components/packaging/static/hash_files !!
 # (no SHA file artifacts on download.docker.com yet as of 2017-06-07 though)
 
-RUN set -ex; \
-# why we use "curl" instead of "wget":
-# + wget -O docker.tgz https://download.docker.com/linux/static/stable/x86_64/docker-17.03.1-ce.tgz
-# Connecting to download.docker.com (54.230.87.253:443)
-# wget: error getting response: Connection reset by peer
-	apk add --no-cache --virtual .fetch-deps \
-		curl \
-		tar \
-	; \
+RUN set -eux; \
 	\
 # this "case" statement is generated via "update.sh"
 	apkArch="$(apk --print-arch)"; \
@@ -36,7 +28,7 @@ RUN set -ex; \
 		*) echo >&2 "error: unsupported architecture ($apkArch)"; exit 1 ;;\
 	esac; \
 	\
-	if ! curl -fL -o docker.tgz "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/${dockerArch}/docker-${DOCKER_VERSION}.tgz"; then \
+	if ! wget -O docker.tgz "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/${dockerArch}/docker-${DOCKER_VERSION}.tgz"; then \
 		echo >&2 "error: failed to download 'docker-${DOCKER_VERSION}' from '${DOCKER_CHANNEL}' for '${dockerArch}'"; \
 		exit 1; \
 	fi; \
@@ -48,10 +40,8 @@ RUN set -ex; \
 	; \
 	rm docker.tgz; \
 	\
-	apk del .fetch-deps; \
-	\
-	dockerd -v; \
-	docker -v
+	dockerd --version; \
+	docker --version
 
 COPY modprobe.sh /usr/local/bin/modprobe
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/18.06/dind/Dockerfile
+++ b/18.06/dind/Dockerfile
@@ -31,11 +31,9 @@ RUN set -x \
 # https://github.com/docker/docker/tree/master/hack/dind
 ENV DIND_COMMIT 52379fa76dee07ca038624d639d9e14f4fb719ff
 
-RUN set -ex; \
-	apk add --no-cache --virtual .fetch-deps libressl; \
+RUN set -eux; \
 	wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind"; \
-	chmod +x /usr/local/bin/dind; \
-	apk del .fetch-deps
+	chmod +x /usr/local/bin/dind
 
 COPY dockerd-entrypoint.sh /usr/local/bin/
 

--- a/18.09-rc/Dockerfile
+++ b/18.09-rc/Dockerfile
@@ -15,15 +15,7 @@ ENV DOCKER_VERSION 18.09.0-ce-beta1
 # https://github.com/docker/docker-ce/blob/5b073ee2cf564edee5adca05eee574142f7627bb/components/packaging/static/hash_files !!
 # (no SHA file artifacts on download.docker.com yet as of 2017-06-07 though)
 
-RUN set -ex; \
-# why we use "curl" instead of "wget":
-# + wget -O docker.tgz https://download.docker.com/linux/static/stable/x86_64/docker-17.03.1-ce.tgz
-# Connecting to download.docker.com (54.230.87.253:443)
-# wget: error getting response: Connection reset by peer
-	apk add --no-cache --virtual .fetch-deps \
-		curl \
-		tar \
-	; \
+RUN set -eux; \
 	\
 # this "case" statement is generated via "update.sh"
 	apkArch="$(apk --print-arch)"; \
@@ -36,7 +28,7 @@ RUN set -ex; \
 		*) echo >&2 "error: unsupported architecture ($apkArch)"; exit 1 ;;\
 	esac; \
 	\
-	if ! curl -fL -o docker.tgz "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/${dockerArch}/docker-${DOCKER_VERSION}.tgz"; then \
+	if ! wget -O docker.tgz "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/${dockerArch}/docker-${DOCKER_VERSION}.tgz"; then \
 		echo >&2 "error: failed to download 'docker-${DOCKER_VERSION}' from '${DOCKER_CHANNEL}' for '${dockerArch}'"; \
 		exit 1; \
 	fi; \
@@ -48,10 +40,8 @@ RUN set -ex; \
 	; \
 	rm docker.tgz; \
 	\
-	apk del .fetch-deps; \
-	\
-	dockerd -v; \
-	docker -v
+	dockerd --version; \
+	docker --version
 
 COPY modprobe.sh /usr/local/bin/modprobe
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/18.09-rc/dind/Dockerfile
+++ b/18.09-rc/dind/Dockerfile
@@ -31,11 +31,9 @@ RUN set -x \
 # https://github.com/docker/docker/tree/master/hack/dind
 ENV DIND_COMMIT 52379fa76dee07ca038624d639d9e14f4fb719ff
 
-RUN set -ex; \
-	apk add --no-cache --virtual .fetch-deps libressl; \
+RUN set -eux; \
 	wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind"; \
-	chmod +x /usr/local/bin/dind; \
-	apk del .fetch-deps
+	chmod +x /usr/local/bin/dind
 
 COPY dockerd-entrypoint.sh /usr/local/bin/
 

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -31,11 +31,9 @@ RUN set -x \
 # https://github.com/docker/docker/tree/master/hack/dind
 ENV DIND_COMMIT %%DIND-COMMIT%%
 
-RUN set -ex; \
-	apk add --no-cache --virtual .fetch-deps libressl; \
+RUN set -eux; \
 	wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind"; \
-	chmod +x /usr/local/bin/dind; \
-	apk del .fetch-deps
+	chmod +x /usr/local/bin/dind
 
 COPY dockerd-entrypoint.sh /usr/local/bin/
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -15,20 +15,12 @@ ENV DOCKER_VERSION %%DOCKER-VERSION%%
 # https://github.com/docker/docker-ce/blob/5b073ee2cf564edee5adca05eee574142f7627bb/components/packaging/static/hash_files !!
 # (no SHA file artifacts on download.docker.com yet as of 2017-06-07 though)
 
-RUN set -ex; \
-# why we use "curl" instead of "wget":
-# + wget -O docker.tgz https://download.docker.com/linux/static/stable/x86_64/docker-17.03.1-ce.tgz
-# Connecting to download.docker.com (54.230.87.253:443)
-# wget: error getting response: Connection reset by peer
-	apk add --no-cache --virtual .fetch-deps \
-		curl \
-		tar \
-	; \
+RUN set -eux; \
 	\
 # this "case" statement is generated via "update.sh"
 	%%ARCH-CASE%%; \
 	\
-	if ! curl -fL -o docker.tgz "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/${dockerArch}/docker-${DOCKER_VERSION}.tgz"; then \
+	if ! wget -O docker.tgz "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/${dockerArch}/docker-${DOCKER_VERSION}.tgz"; then \
 		echo >&2 "error: failed to download 'docker-${DOCKER_VERSION}' from '${DOCKER_CHANNEL}' for '${dockerArch}'"; \
 		exit 1; \
 	fi; \
@@ -40,10 +32,8 @@ RUN set -ex; \
 	; \
 	rm docker.tgz; \
 	\
-	apk del .fetch-deps; \
-	\
-	dockerd -v; \
-	docker -v
+	dockerd --version; \
+	docker --version
 
 COPY modprobe.sh /usr/local/bin/modprobe
 COPY docker-entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
Alpine 3.8's `wget` appears to work fine now, and already includes bits necessary for TLS, so this Just Works™ now. :+1: