### PR TITLE
prefer posix shell built-ins over `which`

### DIFF
--- a/18.06/dind/dockerd-entrypoint.sh
+++ b/18.06/dind/dockerd-entrypoint.sh
@@ -13,7 +13,7 @@ fi
 
 if [ "$1" = 'dockerd' ]; then
 	# if we're running Docker, let's pipe through dind
-	set -- "$(which dind)" "$@"
+	set -- "$(command -v dind)" "$@"
 
 	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
 	find /run /var/run -iname 'docker*.pid' -delete

--- a/18.09-rc/dind/dockerd-entrypoint.sh
+++ b/18.09-rc/dind/dockerd-entrypoint.sh
@@ -13,7 +13,7 @@ fi
 
 if [ "$1" = 'dockerd' ]; then
 	# if we're running Docker, let's pipe through dind
-	set -- "$(which dind)" "$@"
+	set -- "$(command -v dind)" "$@"
 
 	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
 	find /run /var/run -iname 'docker*.pid' -delete

--- a/18.09/dind/dockerd-entrypoint.sh
+++ b/18.09/dind/dockerd-entrypoint.sh
@@ -13,7 +13,7 @@ fi
 
 if [ "$1" = 'dockerd' ]; then
 	# if we're running Docker, let's pipe through dind
-	set -- "$(which dind)" "$@"
+	set -- "$(command -v dind)" "$@"
 
 	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
 	find /run /var/run -iname 'docker*.pid' -delete

--- a/19.03-rc/dind/dockerd-entrypoint.sh
+++ b/19.03-rc/dind/dockerd-entrypoint.sh
@@ -13,7 +13,7 @@ fi
 
 if [ "$1" = 'dockerd' ]; then
 	# if we're running Docker, let's pipe through dind
-	set -- "$(which dind)" "$@"
+	set -- "$(command -v dind)" "$@"
 
 	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
 	find /run /var/run -iname 'docker*.pid' -delete

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -13,7 +13,7 @@ fi
 
 if [ "$1" = 'dockerd' ]; then
 	# if we're running Docker, let's pipe through dind
-	set -- "$(which dind)" "$@"
+	set -- "$(command -v dind)" "$@"
 
 	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
 	find /run /var/run -iname 'docker*.pid' -delete


### PR DESCRIPTION
As the current docker images are based on alpine, and busybox provides a
`which` command, this is essentially a no-op.  However, I believe it is still
worthwhile as `which` is not included by many minimal images and `shellcheck`
issues a warning on the usage of `which` by default.