### PR TITLE
add DOCKER_HOST as a build-arg

### DIFF
--- a/18.06/dind/Dockerfile
+++ b/18.06/dind/Dockerfile
@@ -1,5 +1,8 @@
 FROM docker:18.06
 
+ARG DOCKER_HOST
+ENV DOCKER_HOST=$DOCKER_HOST
+
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN set -eux; \
 	apk add --no-cache \

--- a/18.06/dind/dockerd-entrypoint.sh
+++ b/18.06/dind/dockerd-entrypoint.sh
@@ -1,13 +1,15 @@
 #!/bin/sh
 set -e
 
+DOCKER_HOST=${DOCKER_HOST:-tcp://0.0.0.0:2375}
+
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
 	set -- dockerd \
 		--host=unix:///var/run/docker.sock \
-		--host=tcp://0.0.0.0:2375 \
+		--host="${DOCKER_HOST}" \
 		"$@"
 fi
 

--- a/18.09-rc/dind/Dockerfile
+++ b/18.09-rc/dind/Dockerfile
@@ -1,5 +1,8 @@
 FROM docker:18.09-rc
 
+ARG DOCKER_HOST
+ENV DOCKER_HOST=$DOCKER_HOST
+
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN set -eux; \
 	apk add --no-cache \

--- a/18.09-rc/dind/dockerd-entrypoint.sh
+++ b/18.09-rc/dind/dockerd-entrypoint.sh
@@ -1,13 +1,15 @@
 #!/bin/sh
 set -e
 
+DOCKER_HOST=${DOCKER_HOST:-tcp://0.0.0.0:2375}
+
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
 	set -- dockerd \
 		--host=unix:///var/run/docker.sock \
-		--host=tcp://0.0.0.0:2375 \
+		--host="${DOCKER_HOST}" \
 		"$@"
 fi
 

--- a/18.09/dind/Dockerfile
+++ b/18.09/dind/Dockerfile
@@ -1,5 +1,8 @@
 FROM docker:18.09
 
+ARG DOCKER_HOST
+ENV DOCKER_HOST=$DOCKER_HOST
+
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN set -eux; \
 	apk add --no-cache \

--- a/18.09/dind/dockerd-entrypoint.sh
+++ b/18.09/dind/dockerd-entrypoint.sh
@@ -1,13 +1,15 @@
 #!/bin/sh
 set -e
 
+DOCKER_HOST=${DOCKER_HOST:-tcp://0.0.0.0:2375}
+
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
 	set -- dockerd \
 		--host=unix:///var/run/docker.sock \
-		--host=tcp://0.0.0.0:2375 \
+		--host="${DOCKER_HOST}" \
 		"$@"
 fi
 

--- a/19.03-rc/dind/Dockerfile
+++ b/19.03-rc/dind/Dockerfile
@@ -1,5 +1,8 @@
 FROM docker:19.03-rc
 
+ARG DOCKER_HOST
+ENV DOCKER_HOST=$DOCKER_HOST
+
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN set -eux; \
 	apk add --no-cache \

--- a/19.03-rc/dind/dockerd-entrypoint.sh
+++ b/19.03-rc/dind/dockerd-entrypoint.sh
@@ -1,13 +1,15 @@
 #!/bin/sh
 set -e
 
+DOCKER_HOST=${DOCKER_HOST:-tcp://0.0.0.0:2375}
+
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
 	set -- dockerd \
 		--host=unix:///var/run/docker.sock \
-		--host=tcp://0.0.0.0:2375 \
+		--host="${DOCKER_HOST}" \
 		"$@"
 fi
 

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -1,5 +1,8 @@
 FROM docker:%%VERSION%%
 
+ARG DOCKER_HOST
+ENV DOCKER_HOST=$DOCKER_HOST
+
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN set -eux; \
 	apk add --no-cache \

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -1,13 +1,15 @@
 #!/bin/sh
 set -e
 
+DOCKER_HOST=${DOCKER_HOST:-tcp://0.0.0.0:2375}
+
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
 	set -- dockerd \
 		--host=unix:///var/run/docker.sock \
-		--host=tcp://0.0.0.0:2375 \
+		--host="${DOCKER_HOST}" \
 		"$@"
 fi
 


### PR DESCRIPTION
The current default is for dockerd to be world accessible.  This is
sub-optimal for many use scenarios and can not be overridden without
editing the Dockerfile. Per `docker info`:

    WARNING: API is accessible on http://0.0.0.0:2375 without encryption.
             Access to the remote API is equivalent to root access on the host. Refer
             to the 'Docker daemon attack surface' section in the documentation for
             more information: https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface

This changset preserves the existing default build behavior while
enabling the construction of more restricted image. Eg.,

    docker build . --build-arg DOCKER_HOST=tcp://127.0.0.1:2375