### PR TITLE
Add dind-rootless

### DIFF
--- a/19.03-rc/dind-rootless/Dockerfile
+++ b/19.03-rc/dind-rootless/Dockerfile
@@ -1,0 +1,27 @@
+FROM docker:19.03-rc-dind
+
+RUN apk add --no-cache shadow-uidmap iproute2
+
+ARG ROOTLESS_EXTRAS_URL=https://download.docker.com/linux/static/nightly/x86_64/docker-rootless-extras-0.0.0-20190710010648-0143db1.tgz
+RUN mkdir -p /tmp/extras && \
+ wget -O - $ROOTLESS_EXTRAS_URL | tar xzvf - -C /tmp/extras && \
+ mv /tmp/extras/docker-rootless-extras/* /usr/local/bin && \
+ rm -rf /tmp/extras
+COPY dockerd-rootless-entrypoint.sh /usr/local/bin
+
+ARG ROOTLESS_USER_ID=1000
+ARG ROOTLESS_USER_SUBID_BEGIN=100000
+ARG ROOTLESS_USER_SUBID_LENGTH=65536
+RUN adduser -D -u $ROOTLESS_USER_ID user \
+ && mkdir -p /run/user/$ROOTLESS_USER_ID /home/user/.local/share/docker \
+ && chown -R user /run/user/$ROOTLESS_USER_ID /home/user \
+ && echo user:$ROOTLESS_USER_SUBID_BEGIN:$ROOTLESS_USER_SUBID_LENGTH | tee /etc/subuid | tee /etc/subgid
+
+USER user
+ENV HOME /home/user
+ENV USER user
+ENV XDG_RUNTIME_DIR=/run/user/$ROOTLESS_USER_ID
+ENV DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock
+VOLUME /home/user/.local/share/docker
+
+ENTRYPOINT ["dockerd-rootless-entrypoint.sh"]

--- a/19.03-rc/dind-rootless/dockerd-rootless-entrypoint.sh
+++ b/19.03-rc/dind-rootless/dockerd-rootless-entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -e
+
+INSTRUCTIONS=""
+# debian requires setting unprivileged_userns_clone
+if [ -f /proc/sys/kernel/unprivileged_userns_clone ]; then
+	if [ "1" != "$(cat /proc/sys/kernel/unprivileged_userns_clone)" ]; then
+		INSTRUCTIONS="${INSTRUCTIONS}
+cat <<EOT > /etc/sysctl.d/50-rootless.conf
+kernel.unprivileged_userns_clone = 1
+EOT
+sysctl --system"
+	fi
+fi
+
+# centos requires setting max_user_namespaces
+if [ -f /proc/sys/user/max_user_namespaces ]; then
+	if [ "0" = "$(cat /proc/sys/user/max_user_namespaces)" ]; then
+		INSTRUCTIONS="${INSTRUCTIONS}
+cat <<EOT > /etc/sysctl.d/51-rootless.conf
+user.max_user_namespaces = 28633
+EOT
+sysctl --system"
+	fi
+fi
+
+if [ -n "$INSTRUCTIONS" ]; then
+	echo "# Missing system requirements. Please run following commands on the host."
+	echo
+	echo "$INSTRUCTIONS"
+	exit 1
+fi
+
+DOCKERD_FLAGS="--experimental"
+# detect if overlay is supported (ubuntu)
+tmpdir=$(mktemp -d)
+mkdir -p $tmpdir/lower $tmpdir/upper $tmpdir/work $tmpdir/merged
+if rootlesskit mount -t overlay overlay -olowerdir=$tmpdir/lower,upperdir=$tmpdir/upper,workdir=$tmpdir/work $tmpdir/merged >/dev/null 2>&1; then
+	DOCKERD_FLAGS="$DOCKERD_FLAGS --storage-driver=overlay2"
+else
+	DOCKERD_FLAGS="$DOCKERD_FLAGS --storage-driver=vfs"
+fi
+rm -rf "$tmpdir"
+
+exec dockerd-rootless.sh "$DOCKERD_FLAGS" "$@"

--- a/Dockerfile-dind-rootless.template
+++ b/Dockerfile-dind-rootless.template
@@ -1,0 +1,27 @@
+FROM docker:%%VERSION%%-dind
+
+RUN apk add --no-cache shadow-uidmap iproute2
+
+ARG ROOTLESS_EXTRAS_URL=%%ROOTLESS-EXTRAS-URL%%
+RUN mkdir -p /tmp/extras && \
+ wget -O - $ROOTLESS_EXTRAS_URL | tar xzvf - -C /tmp/extras && \
+ mv /tmp/extras/docker-rootless-extras/* /usr/local/bin && \
+ rm -rf /tmp/extras
+COPY dockerd-rootless-entrypoint.sh /usr/local/bin
+
+ARG ROOTLESS_USER_ID=1000
+ARG ROOTLESS_USER_SUBID_BEGIN=100000
+ARG ROOTLESS_USER_SUBID_LENGTH=65536
+RUN adduser -D -u $ROOTLESS_USER_ID user \
+ && mkdir -p /run/user/$ROOTLESS_USER_ID /home/user/.local/share/docker \
+ && chown -R user /run/user/$ROOTLESS_USER_ID /home/user \
+ && echo user:$ROOTLESS_USER_SUBID_BEGIN:$ROOTLESS_USER_SUBID_LENGTH | tee /etc/subuid | tee /etc/subgid
+
+USER user
+ENV HOME /home/user
+ENV USER user
+ENV XDG_RUNTIME_DIR=/run/user/$ROOTLESS_USER_ID
+ENV DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock
+VOLUME /home/user/.local/share/docker
+
+ENTRYPOINT ["dockerd-rootless-entrypoint.sh"]

--- a/dockerd-rootless-entrypoint.sh
+++ b/dockerd-rootless-entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -e
+
+INSTRUCTIONS=""
+# debian requires setting unprivileged_userns_clone
+if [ -f /proc/sys/kernel/unprivileged_userns_clone ]; then
+	if [ "1" != "$(cat /proc/sys/kernel/unprivileged_userns_clone)" ]; then
+		INSTRUCTIONS="${INSTRUCTIONS}
+cat <<EOT > /etc/sysctl.d/50-rootless.conf
+kernel.unprivileged_userns_clone = 1
+EOT
+sysctl --system"
+	fi
+fi
+
+# centos requires setting max_user_namespaces
+if [ -f /proc/sys/user/max_user_namespaces ]; then
+	if [ "0" = "$(cat /proc/sys/user/max_user_namespaces)" ]; then
+		INSTRUCTIONS="${INSTRUCTIONS}
+cat <<EOT > /etc/sysctl.d/51-rootless.conf
+user.max_user_namespaces = 28633
+EOT
+sysctl --system"
+	fi
+fi
+
+if [ -n "$INSTRUCTIONS" ]; then
+	echo "# Missing system requirements. Please run following commands on the host."
+	echo
+	echo "$INSTRUCTIONS"
+	exit 1
+fi
+
+DOCKERD_FLAGS="--experimental"
+# detect if overlay is supported (ubuntu)
+tmpdir=$(mktemp -d)
+mkdir -p $tmpdir/lower $tmpdir/upper $tmpdir/work $tmpdir/merged
+if rootlesskit mount -t overlay overlay -olowerdir=$tmpdir/lower,upperdir=$tmpdir/upper,workdir=$tmpdir/work $tmpdir/merged >/dev/null 2>&1; then
+	DOCKERD_FLAGS="$DOCKERD_FLAGS --storage-driver=overlay2"
+else
+	DOCKERD_FLAGS="$DOCKERD_FLAGS --storage-driver=vfs"
+fi
+rm -rf "$tmpdir"
+
+exec dockerd-rootless.sh "$DOCKERD_FLAGS" "$@"

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -145,7 +145,7 @@ for version in "${versions[@]}"; do
 	EOE
 
 	for v in \
-		dind git \
+		dind dind-rootless git \
 		windows/windowsservercore-{ltsc2016,1709} \
 	; do
 		dir="$version/$v"

--- a/update.sh
+++ b/update.sh
@@ -105,9 +105,10 @@ for version in "${versions[@]}"; do
 	minorVersion="${fullVersion#$majorVersion.}"
 	minorVersion="${minorVersion%%.*}"
 	minorVersion="${minorVersion#0}"
+	rootlessExtrasURL="https://download.docker.com/linux/static/nightly/x86_64/docker-rootless-extras-0.0.0-20190710010648-0143db1.tgz"
 
 	for variant in \
-		'' git dind \
+		'' git dind dind-rootless \
 		windows/windowsservercore-{1709,ltsc2016} \
 	; do
 		dir="$version${variant:+/$variant}"
@@ -125,6 +126,7 @@ for version in "${versions[@]}"; do
 			-e 's!%%TAG%%!'"$tag"'!g' \
 			-e 's!%%DIND-COMMIT%%!'"$dindLatest"'!g' \
 			-e 's!%%ARCH-CASE%%!'"$(sed_escape_rhs "$archCase")"'!g' \
+			-e 's!%%ROOTLESS-EXTRAS-URL%%!'"$rootlessExtrasURL"'!g' \
 			"$template" > "$df"
 
 		# pigz (https://github.com/moby/moby/pull/35697) is only 18.02+
@@ -144,6 +146,7 @@ for version in "${versions[@]}"; do
 
 	cp -a docker-entrypoint.sh modprobe.sh "$version/"
 	cp -a dockerd-entrypoint.sh "$version/dind/"
+	[ -d "$version/dind-rootless" ] && cp -a dockerd-rootless-entrypoint.sh "$version/dind-rootless/"
 
 	travisEnv='\n  - VERSION='"$version$travisEnv"
 done


### PR DESCRIPTION
Usage:
```
$ docker build -t dind-rootless .
$ docker run -d --name dind-rootless --privileged dind-rootless
$ docker exec dind-rootless docker info
```

* The daemon runs in an unprivileged user with ID 1000
* `--privileged` is still required due to seccomp, apparmor, procfs, and sysfs stuff
- [ ] `-H tcp://....` will be supported soon: https://github.com/moby/moby/pull/39493
- [ ] known not to work on Fedora currently due to a containerd issue https://github.com/docker-library/docker/pull/165#issuecomment-511717143 (PR: https://github.com/containerd/containerd/pull/3419)

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>