### PR TITLE
Add automatic TLS generation (and enable it by default in 19.03+)

### DIFF
--- a/18.09-rc/Dockerfile
+++ b/18.09-rc/Dockerfile
@@ -49,5 +49,11 @@ RUN set -eux; \
 COPY modprobe.sh /usr/local/bin/modprobe
 COPY docker-entrypoint.sh /usr/local/bin/
 
+# https://github.com/docker-library/docker/pull/166
+#   dockerd-entrypoint.sh uses DOCKER_TLS_CERTDIR for auto-generating TLS certificates
+#   docker-entrypoint.sh uses DOCKER_TLS_CERTDIR for auto-setting DOCKER_TLS_VERIFY and DOCKER_CERT_PATH
+# (For this to work, at least the "client" subdirectory of this path needs to be shared between the client and server containers via a volume, "docker cp", or other means of data sharing.)
+ENV DOCKER_TLS_CERTDIR=
+
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["sh"]

--- a/18.09-rc/dind/Dockerfile
+++ b/18.09-rc/dind/Dockerfile
@@ -7,6 +7,7 @@ RUN set -eux; \
 		e2fsprogs \
 		e2fsprogs-extra \
 		iptables \
+		openssl \
 		xfsprogs \
 		xz \
 # pigz: https://github.com/moby/moby/pull/35697 (faster gzip implementation)
@@ -38,7 +39,7 @@ RUN set -eux; \
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 VOLUME /var/lib/docker
-EXPOSE 2375
+EXPOSE 2375 2376
 
 ENTRYPOINT ["dockerd-entrypoint.sh"]
 CMD []

--- a/18.09-rc/dind/dockerd-entrypoint.sh
+++ b/18.09-rc/dind/dockerd-entrypoint.sh
@@ -1,14 +1,119 @@
 #!/bin/sh
-set -e
+set -eu
+
+_tls_ensure_private() {
+	local f="$1"; shift
+	[ -s "$f" ] || openssl genrsa -out "$f" 4196
+}
+_tls_san() {
+	{
+		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
+		{
+			cat /etc/hostname
+			echo 'docker'
+			echo 'localhost'
+			hostname -f
+			hostname -s
+		} | sed 's/^/DNS:/'
+		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
+	} | sort -u | xargs printf '%s,' | sed "s/,\$//"
+}
+_tls_generate_certs() {
+	local dir="$1"; shift
+
+	# if ca/key.pem || !ca/cert.pem, generate CA public if necessary
+	# if ca/key.pem, generate server public
+	# if ca/key.pem, generate client public
+	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
+
+	# https://github.com/FiloSottile/mkcert/issues/174
+	local certValidDays='825'
+
+	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
+		# if we either have a CA private key or do *not* have a CA public key, then we should create/manage the CA
+		mkdir -p "$dir/ca"
+		_tls_ensure_private "$dir/ca/key.pem"
+		openssl req -new -key "$dir/ca/key.pem" \
+			-out "$dir/ca/cert.pem" \
+			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a server key
+		mkdir -p "$dir/server"
+		_tls_ensure_private "$dir/server/key.pem"
+		openssl req -new -key "$dir/server/key.pem" \
+			-out "$dir/server/csr.pem" \
+			-subj '/CN=docker:dind server'
+		cat > "$dir/server/openssl.cnf" <<-EOF
+			[ x509_exts ]
+			subjectAltName = $(_tls_san)
+		EOF
+		openssl x509 -req \
+				-in "$dir/server/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/server/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/server/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
+		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a client key
+		mkdir -p "$dir/client"
+		_tls_ensure_private "$dir/client/key.pem"
+		openssl req -new \
+				-key "$dir/client/key.pem" \
+				-out "$dir/client/csr.pem" \
+				-subj '/CN=docker:dind client'
+		cat > "$dir/client/openssl.cnf" <<-'EOF'
+			[ x509_exts ]
+			extendedKeyUsage = clientAuth
+		EOF
+		openssl x509 -req \
+				-in "$dir/client/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/client/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/client/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
+		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
+	fi
+}
 
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
-	set -- dockerd \
-		--host=unix:///var/run/docker.sock \
-		--host=tcp://0.0.0.0:2375 \
-		"$@"
+	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
+		&& _tls_generate_certs "$DOCKER_TLS_CERTDIR" \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ] \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ] \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ] \
+	; then
+		# generate certs and use TLS if requested/possible (default in 19.03+)
+		set -- dockerd \
+			--host=unix:///var/run/docker.sock \
+			--host=tcp://0.0.0.0:2376 \
+			--tlsverify \
+			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
+			--tlscert "$DOCKER_TLS_CERTDIR/server/cert.pem" \
+			--tlskey "$DOCKER_TLS_CERTDIR/server/key.pem" \
+			"$@"
+	else
+		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
+		set -- dockerd \
+			--host=unix:///var/run/docker.sock \
+			--host=tcp://0.0.0.0:2375 \
+			"$@"
+	fi
 fi
 
 if [ "$1" = 'dockerd' ]; then

--- a/18.09-rc/docker-entrypoint.sh
+++ b/18.09-rc/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -eu
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then
@@ -12,9 +12,24 @@ if docker help "$1" > /dev/null 2>&1; then
 	set -- docker "$@"
 fi
 
-# if we have "--link some-docker:docker" and not DOCKER_HOST, let's set DOCKER_HOST automatically
-if [ -z "$DOCKER_HOST" -a "$DOCKER_PORT_2375_TCP" ]; then
-	export DOCKER_HOST='tcp://docker:2375'
+_should_tls() {
+	[ -n "${DOCKER_TLS_CERTDIR:-}" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/ca.pem" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/cert.pem" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/key.pem" ]
+}
+
+# if DOCKER_HOST isn't set and we don't have the default unix socket, let's set DOCKER_HOST to a sane remote value
+if [ -z "${DOCKER_HOST:-}" ] && [ ! -S /var/run/docker.sock ]; then
+	if _should_tls || [ -n "${DOCKER_TLS_VERIFY:-}" ]; then
+		export DOCKER_HOST='tcp://docker:2376'
+	else
+		export DOCKER_HOST='tcp://docker:2375'
+	fi
+fi
+if [ -n "${DOCKER_HOST:-}" ] && _should_tls; then
+	export DOCKER_TLS_VERIFY=1
+	export DOCKER_CERT_PATH="$DOCKER_TLS_CERTDIR/client"
 fi
 
 if [ "$1" = 'dockerd' ]; then

--- a/18.09/Dockerfile
+++ b/18.09/Dockerfile
@@ -49,5 +49,11 @@ RUN set -eux; \
 COPY modprobe.sh /usr/local/bin/modprobe
 COPY docker-entrypoint.sh /usr/local/bin/
 
+# https://github.com/docker-library/docker/pull/166
+#   dockerd-entrypoint.sh uses DOCKER_TLS_CERTDIR for auto-generating TLS certificates
+#   docker-entrypoint.sh uses DOCKER_TLS_CERTDIR for auto-setting DOCKER_TLS_VERIFY and DOCKER_CERT_PATH
+# (For this to work, at least the "client" subdirectory of this path needs to be shared between the client and server containers via a volume, "docker cp", or other means of data sharing.)
+ENV DOCKER_TLS_CERTDIR=
+
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["sh"]

--- a/18.09/dind/Dockerfile
+++ b/18.09/dind/Dockerfile
@@ -7,6 +7,7 @@ RUN set -eux; \
 		e2fsprogs \
 		e2fsprogs-extra \
 		iptables \
+		openssl \
 		xfsprogs \
 		xz \
 # pigz: https://github.com/moby/moby/pull/35697 (faster gzip implementation)
@@ -38,7 +39,7 @@ RUN set -eux; \
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 VOLUME /var/lib/docker
-EXPOSE 2375
+EXPOSE 2375 2376
 
 ENTRYPOINT ["dockerd-entrypoint.sh"]
 CMD []

--- a/18.09/dind/dockerd-entrypoint.sh
+++ b/18.09/dind/dockerd-entrypoint.sh
@@ -1,14 +1,119 @@
 #!/bin/sh
-set -e
+set -eu
+
+_tls_ensure_private() {
+	local f="$1"; shift
+	[ -s "$f" ] || openssl genrsa -out "$f" 4196
+}
+_tls_san() {
+	{
+		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
+		{
+			cat /etc/hostname
+			echo 'docker'
+			echo 'localhost'
+			hostname -f
+			hostname -s
+		} | sed 's/^/DNS:/'
+		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
+	} | sort -u | xargs printf '%s,' | sed "s/,\$//"
+}
+_tls_generate_certs() {
+	local dir="$1"; shift
+
+	# if ca/key.pem || !ca/cert.pem, generate CA public if necessary
+	# if ca/key.pem, generate server public
+	# if ca/key.pem, generate client public
+	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
+
+	# https://github.com/FiloSottile/mkcert/issues/174
+	local certValidDays='825'
+
+	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
+		# if we either have a CA private key or do *not* have a CA public key, then we should create/manage the CA
+		mkdir -p "$dir/ca"
+		_tls_ensure_private "$dir/ca/key.pem"
+		openssl req -new -key "$dir/ca/key.pem" \
+			-out "$dir/ca/cert.pem" \
+			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a server key
+		mkdir -p "$dir/server"
+		_tls_ensure_private "$dir/server/key.pem"
+		openssl req -new -key "$dir/server/key.pem" \
+			-out "$dir/server/csr.pem" \
+			-subj '/CN=docker:dind server'
+		cat > "$dir/server/openssl.cnf" <<-EOF
+			[ x509_exts ]
+			subjectAltName = $(_tls_san)
+		EOF
+		openssl x509 -req \
+				-in "$dir/server/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/server/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/server/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
+		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a client key
+		mkdir -p "$dir/client"
+		_tls_ensure_private "$dir/client/key.pem"
+		openssl req -new \
+				-key "$dir/client/key.pem" \
+				-out "$dir/client/csr.pem" \
+				-subj '/CN=docker:dind client'
+		cat > "$dir/client/openssl.cnf" <<-'EOF'
+			[ x509_exts ]
+			extendedKeyUsage = clientAuth
+		EOF
+		openssl x509 -req \
+				-in "$dir/client/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/client/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/client/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
+		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
+	fi
+}
 
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
-	set -- dockerd \
-		--host=unix:///var/run/docker.sock \
-		--host=tcp://0.0.0.0:2375 \
-		"$@"
+	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
+		&& _tls_generate_certs "$DOCKER_TLS_CERTDIR" \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ] \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ] \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ] \
+	; then
+		# generate certs and use TLS if requested/possible (default in 19.03+)
+		set -- dockerd \
+			--host=unix:///var/run/docker.sock \
+			--host=tcp://0.0.0.0:2376 \
+			--tlsverify \
+			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
+			--tlscert "$DOCKER_TLS_CERTDIR/server/cert.pem" \
+			--tlskey "$DOCKER_TLS_CERTDIR/server/key.pem" \
+			"$@"
+	else
+		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
+		set -- dockerd \
+			--host=unix:///var/run/docker.sock \
+			--host=tcp://0.0.0.0:2375 \
+			"$@"
+	fi
 fi
 
 if [ "$1" = 'dockerd' ]; then

--- a/18.09/docker-entrypoint.sh
+++ b/18.09/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -eu
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then
@@ -12,9 +12,24 @@ if docker help "$1" > /dev/null 2>&1; then
 	set -- docker "$@"
 fi
 
-# if we have "--link some-docker:docker" and not DOCKER_HOST, let's set DOCKER_HOST automatically
-if [ -z "$DOCKER_HOST" -a "$DOCKER_PORT_2375_TCP" ]; then
-	export DOCKER_HOST='tcp://docker:2375'
+_should_tls() {
+	[ -n "${DOCKER_TLS_CERTDIR:-}" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/ca.pem" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/cert.pem" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/key.pem" ]
+}
+
+# if DOCKER_HOST isn't set and we don't have the default unix socket, let's set DOCKER_HOST to a sane remote value
+if [ -z "${DOCKER_HOST:-}" ] && [ ! -S /var/run/docker.sock ]; then
+	if _should_tls || [ -n "${DOCKER_TLS_VERIFY:-}" ]; then
+		export DOCKER_HOST='tcp://docker:2376'
+	else
+		export DOCKER_HOST='tcp://docker:2375'
+	fi
+fi
+if [ -n "${DOCKER_HOST:-}" ] && _should_tls; then
+	export DOCKER_TLS_VERIFY=1
+	export DOCKER_CERT_PATH="$DOCKER_TLS_CERTDIR/client"
 fi
 
 if [ "$1" = 'dockerd' ]; then

--- a/19.03-rc/Dockerfile
+++ b/19.03-rc/Dockerfile
@@ -49,5 +49,11 @@ RUN set -eux; \
 COPY modprobe.sh /usr/local/bin/modprobe
 COPY docker-entrypoint.sh /usr/local/bin/
 
+# https://github.com/docker-library/docker/pull/166
+#   dockerd-entrypoint.sh uses DOCKER_TLS_CERTDIR for auto-generating TLS certificates
+#   docker-entrypoint.sh uses DOCKER_TLS_CERTDIR for auto-setting DOCKER_TLS_VERIFY and DOCKER_CERT_PATH
+# (For this to work, at least the "client" subdirectory of this path needs to be shared between the client and server containers via a volume, "docker cp", or other means of data sharing.)
+ENV DOCKER_TLS_CERTDIR=/certs
+
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["sh"]

--- a/19.03-rc/dind/Dockerfile
+++ b/19.03-rc/dind/Dockerfile
@@ -7,6 +7,7 @@ RUN set -eux; \
 		e2fsprogs \
 		e2fsprogs-extra \
 		iptables \
+		openssl \
 		xfsprogs \
 		xz \
 # pigz: https://github.com/moby/moby/pull/35697 (faster gzip implementation)
@@ -38,7 +39,7 @@ RUN set -eux; \
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 VOLUME /var/lib/docker
-EXPOSE 2375
+EXPOSE 2375 2376
 
 ENTRYPOINT ["dockerd-entrypoint.sh"]
 CMD []

--- a/19.03-rc/dind/dockerd-entrypoint.sh
+++ b/19.03-rc/dind/dockerd-entrypoint.sh
@@ -1,14 +1,119 @@
 #!/bin/sh
-set -e
+set -eu
+
+_tls_ensure_private() {
+	local f="$1"; shift
+	[ -s "$f" ] || openssl genrsa -out "$f" 4196
+}
+_tls_san() {
+	{
+		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
+		{
+			cat /etc/hostname
+			echo 'docker'
+			echo 'localhost'
+			hostname -f
+			hostname -s
+		} | sed 's/^/DNS:/'
+		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
+	} | sort -u | xargs printf '%s,' | sed "s/,\$//"
+}
+_tls_generate_certs() {
+	local dir="$1"; shift
+
+	# if ca/key.pem || !ca/cert.pem, generate CA public if necessary
+	# if ca/key.pem, generate server public
+	# if ca/key.pem, generate client public
+	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
+
+	# https://github.com/FiloSottile/mkcert/issues/174
+	local certValidDays='825'
+
+	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
+		# if we either have a CA private key or do *not* have a CA public key, then we should create/manage the CA
+		mkdir -p "$dir/ca"
+		_tls_ensure_private "$dir/ca/key.pem"
+		openssl req -new -key "$dir/ca/key.pem" \
+			-out "$dir/ca/cert.pem" \
+			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a server key
+		mkdir -p "$dir/server"
+		_tls_ensure_private "$dir/server/key.pem"
+		openssl req -new -key "$dir/server/key.pem" \
+			-out "$dir/server/csr.pem" \
+			-subj '/CN=docker:dind server'
+		cat > "$dir/server/openssl.cnf" <<-EOF
+			[ x509_exts ]
+			subjectAltName = $(_tls_san)
+		EOF
+		openssl x509 -req \
+				-in "$dir/server/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/server/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/server/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
+		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a client key
+		mkdir -p "$dir/client"
+		_tls_ensure_private "$dir/client/key.pem"
+		openssl req -new \
+				-key "$dir/client/key.pem" \
+				-out "$dir/client/csr.pem" \
+				-subj '/CN=docker:dind client'
+		cat > "$dir/client/openssl.cnf" <<-'EOF'
+			[ x509_exts ]
+			extendedKeyUsage = clientAuth
+		EOF
+		openssl x509 -req \
+				-in "$dir/client/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/client/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/client/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
+		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
+	fi
+}
 
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
-	set -- dockerd \
-		--host=unix:///var/run/docker.sock \
-		--host=tcp://0.0.0.0:2375 \
-		"$@"
+	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
+		&& _tls_generate_certs "$DOCKER_TLS_CERTDIR" \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ] \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ] \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ] \
+	; then
+		# generate certs and use TLS if requested/possible (default in 19.03+)
+		set -- dockerd \
+			--host=unix:///var/run/docker.sock \
+			--host=tcp://0.0.0.0:2376 \
+			--tlsverify \
+			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
+			--tlscert "$DOCKER_TLS_CERTDIR/server/cert.pem" \
+			--tlskey "$DOCKER_TLS_CERTDIR/server/key.pem" \
+			"$@"
+	else
+		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
+		set -- dockerd \
+			--host=unix:///var/run/docker.sock \
+			--host=tcp://0.0.0.0:2375 \
+			"$@"
+	fi
 fi
 
 if [ "$1" = 'dockerd' ]; then

--- a/19.03-rc/docker-entrypoint.sh
+++ b/19.03-rc/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -eu
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then
@@ -12,9 +12,24 @@ if docker help "$1" > /dev/null 2>&1; then
 	set -- docker "$@"
 fi
 
-# if we have "--link some-docker:docker" and not DOCKER_HOST, let's set DOCKER_HOST automatically
-if [ -z "$DOCKER_HOST" -a "$DOCKER_PORT_2375_TCP" ]; then
-	export DOCKER_HOST='tcp://docker:2375'
+_should_tls() {
+	[ -n "${DOCKER_TLS_CERTDIR:-}" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/ca.pem" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/cert.pem" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/key.pem" ]
+}
+
+# if DOCKER_HOST isn't set and we don't have the default unix socket, let's set DOCKER_HOST to a sane remote value
+if [ -z "${DOCKER_HOST:-}" ] && [ ! -S /var/run/docker.sock ]; then
+	if _should_tls || [ -n "${DOCKER_TLS_VERIFY:-}" ]; then
+		export DOCKER_HOST='tcp://docker:2376'
+	else
+		export DOCKER_HOST='tcp://docker:2375'
+	fi
+fi
+if [ -n "${DOCKER_HOST:-}" ] && _should_tls; then
+	export DOCKER_TLS_VERIFY=1
+	export DOCKER_CERT_PATH="$DOCKER_TLS_CERTDIR/client"
 fi
 
 if [ "$1" = 'dockerd' ]; then

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -7,6 +7,7 @@ RUN set -eux; \
 		e2fsprogs \
 		e2fsprogs-extra \
 		iptables \
+		openssl \
 		xfsprogs \
 		xz \
 # pigz: https://github.com/moby/moby/pull/35697 (faster gzip implementation)
@@ -38,7 +39,7 @@ RUN set -eux; \
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 VOLUME /var/lib/docker
-EXPOSE 2375
+EXPOSE 2375 2376
 
 ENTRYPOINT ["dockerd-entrypoint.sh"]
 CMD []

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -38,5 +38,11 @@ RUN set -eux; \
 COPY modprobe.sh /usr/local/bin/modprobe
 COPY docker-entrypoint.sh /usr/local/bin/
 
+# https://github.com/docker-library/docker/pull/166
+#   dockerd-entrypoint.sh uses DOCKER_TLS_CERTDIR for auto-generating TLS certificates
+#   docker-entrypoint.sh uses DOCKER_TLS_CERTDIR for auto-setting DOCKER_TLS_VERIFY and DOCKER_CERT_PATH
+# (For this to work, at least the "client" subdirectory of this path needs to be shared between the client and server containers via a volume, "docker cp", or other means of data sharing.)
+ENV DOCKER_TLS_CERTDIR=/certs
+
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -eu
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then
@@ -12,9 +12,24 @@ if docker help "$1" > /dev/null 2>&1; then
 	set -- docker "$@"
 fi
 
-# if we have "--link some-docker:docker" and not DOCKER_HOST, let's set DOCKER_HOST automatically
-if [ -z "$DOCKER_HOST" -a "$DOCKER_PORT_2375_TCP" ]; then
-	export DOCKER_HOST='tcp://docker:2375'
+_should_tls() {
+	[ -n "${DOCKER_TLS_CERTDIR:-}" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/ca.pem" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/cert.pem" ] \
+	&& [ -s "$DOCKER_TLS_CERTDIR/client/key.pem" ]
+}
+
+# if DOCKER_HOST isn't set and we don't have the default unix socket, let's set DOCKER_HOST to a sane remote value
+if [ -z "${DOCKER_HOST:-}" ] && [ ! -S /var/run/docker.sock ]; then
+	if _should_tls || [ -n "${DOCKER_TLS_VERIFY:-}" ]; then
+		export DOCKER_HOST='tcp://docker:2376'
+	else
+		export DOCKER_HOST='tcp://docker:2375'
+	fi
+fi
+if [ -n "${DOCKER_HOST:-}" ] && _should_tls; then
+	export DOCKER_TLS_VERIFY=1
+	export DOCKER_CERT_PATH="$DOCKER_TLS_CERTDIR/client"
 fi
 
 if [ "$1" = 'dockerd' ]; then

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -1,14 +1,119 @@
 #!/bin/sh
-set -e
+set -eu
+
+_tls_ensure_private() {
+	local f="$1"; shift
+	[ -s "$f" ] || openssl genrsa -out "$f" 4196
+}
+_tls_san() {
+	{
+		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
+		{
+			cat /etc/hostname
+			echo 'docker'
+			echo 'localhost'
+			hostname -f
+			hostname -s
+		} | sed 's/^/DNS:/'
+		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
+	} | sort -u | xargs printf '%s,' | sed "s/,\$//"
+}
+_tls_generate_certs() {
+	local dir="$1"; shift
+
+	# if ca/key.pem || !ca/cert.pem, generate CA public if necessary
+	# if ca/key.pem, generate server public
+	# if ca/key.pem, generate client public
+	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
+
+	# https://github.com/FiloSottile/mkcert/issues/174
+	local certValidDays='825'
+
+	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
+		# if we either have a CA private key or do *not* have a CA public key, then we should create/manage the CA
+		mkdir -p "$dir/ca"
+		_tls_ensure_private "$dir/ca/key.pem"
+		openssl req -new -key "$dir/ca/key.pem" \
+			-out "$dir/ca/cert.pem" \
+			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a server key
+		mkdir -p "$dir/server"
+		_tls_ensure_private "$dir/server/key.pem"
+		openssl req -new -key "$dir/server/key.pem" \
+			-out "$dir/server/csr.pem" \
+			-subj '/CN=docker:dind server'
+		cat > "$dir/server/openssl.cnf" <<-EOF
+			[ x509_exts ]
+			subjectAltName = $(_tls_san)
+		EOF
+		openssl x509 -req \
+				-in "$dir/server/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/server/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/server/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
+		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a client key
+		mkdir -p "$dir/client"
+		_tls_ensure_private "$dir/client/key.pem"
+		openssl req -new \
+				-key "$dir/client/key.pem" \
+				-out "$dir/client/csr.pem" \
+				-subj '/CN=docker:dind client'
+		cat > "$dir/client/openssl.cnf" <<-'EOF'
+			[ x509_exts ]
+			extendedKeyUsage = clientAuth
+		EOF
+		openssl x509 -req \
+				-in "$dir/client/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/client/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/client/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
+		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
+	fi
+}
 
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
-	set -- dockerd \
-		--host=unix:///var/run/docker.sock \
-		--host=tcp://0.0.0.0:2375 \
-		"$@"
+	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
+		&& _tls_generate_certs "$DOCKER_TLS_CERTDIR" \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ] \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ] \
+		&& [ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ] \
+	; then
+		# generate certs and use TLS if requested/possible (default in 19.03+)
+		set -- dockerd \
+			--host=unix:///var/run/docker.sock \
+			--host=tcp://0.0.0.0:2376 \
+			--tlsverify \
+			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
+			--tlscert "$DOCKER_TLS_CERTDIR/server/cert.pem" \
+			--tlskey "$DOCKER_TLS_CERTDIR/server/key.pem" \
+			"$@"
+	else
+		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
+		set -- dockerd \
+			--host=unix:///var/run/docker.sock \
+			--host=tcp://0.0.0.0:2375 \
+			"$@"
+	fi
 fi
 
 if [ "$1" = 'dockerd' ]; then

--- a/update.sh
+++ b/update.sh
@@ -127,6 +127,11 @@ for version in "${versions[@]}"; do
 			-e 's!%%ARCH-CASE%%!'"$(sed_escape_rhs "$archCase")"'!g' \
 			"$template" > "$df"
 
+		# DOCKER_TLS_CERTDIR is only enabled-by-default in 19.03+
+		if [ "$majorVersion" -lt 19 ]; then
+			sed -ri -e 's!^(ENV DOCKER_TLS_CERTDIR=).*$!\1!' "$df"
+		fi
+
 		# pigz (https://github.com/moby/moby/pull/35697) is only 18.02+
 		if [ "$majorVersion" -lt 18 ] || { [ "$majorVersion" -eq 18 ] && [ "$minorVersion" -lt 2 ]; }; then
 			sed -ri '/pigz/d' "$df"


### PR DESCRIPTION
Closes #164
Refs https://github.com/docker-library/docs/pull/1525

This adds a `DOCKER_TLS_CERTDIR` environment variable that, when present, will auto-enable TLS on `dockerd` by default (and will set the appropriate client flags if the necessary certificates exist).

It will attempt to generate a suitable `subjectAltName` extension value based on all available container IP addresses and hostnames, but the default generation can be extended via the `DOCKER_TLS_SAN` environment variable (in the standard OpenSSL format, ala `IP:n.n.n.n,DNS:foobar,...`).

For users of 18.09 who wish to enable this behavior, simply set `DOCKER_TLS_CERTDIR` to a path within the container into which you want certificates generated (and share at least the `client` subdirectory of that path with your client containers). The default value in 19.03+ is `/certs` (so to mimic that, something like `-e DOCKER_TLS_CERTDIR=/certs` would be sufficient/appropriate).

For users of 19.03+ who wish to *disable* this behavior (not recommended), simply set `DOCKER_TLS_CERTDIR` to the empty string (`-e DOCKER_TLS_CERTDIR=`).