### PR TITLE
Use a simpler "dind" example in non-dind images

### DIFF
--- a/18.09-rc/docker-entrypoint.sh
+++ b/18.09-rc/docker-entrypoint.sh
@@ -24,7 +24,7 @@ if [ "$1" = 'dockerd' ]; then
 
 		   You probably should use the "dind" image variant instead, something like:
 
-		     docker run --privileged --name some-overlay-docker -d docker:stable-dind --storage-driver=overlay
+		     docker run --privileged --name some-docker ... docker:dind ...
 
 		   See https://hub.docker.com/_/docker/ for more documentation and usage examples.
 

--- a/18.09/docker-entrypoint.sh
+++ b/18.09/docker-entrypoint.sh
@@ -24,7 +24,7 @@ if [ "$1" = 'dockerd' ]; then
 
 		   You probably should use the "dind" image variant instead, something like:
 
-		     docker run --privileged --name some-overlay-docker -d docker:stable-dind --storage-driver=overlay
+		     docker run --privileged --name some-docker ... docker:dind ...
 
 		   See https://hub.docker.com/_/docker/ for more documentation and usage examples.
 

--- a/19.03-rc/docker-entrypoint.sh
+++ b/19.03-rc/docker-entrypoint.sh
@@ -24,7 +24,7 @@ if [ "$1" = 'dockerd' ]; then
 
 		   You probably should use the "dind" image variant instead, something like:
 
-		     docker run --privileged --name some-overlay-docker -d docker:stable-dind --storage-driver=overlay
+		     docker run --privileged --name some-docker ... docker:dind ...
 
 		   See https://hub.docker.com/_/docker/ for more documentation and usage examples.
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,7 +24,7 @@ if [ "$1" = 'dockerd' ]; then
 
 		   You probably should use the "dind" image variant instead, something like:
 
-		     docker run --privileged --name some-overlay-docker -d docker:stable-dind --storage-driver=overlay
+		     docker run --privileged --name some-docker ... docker:dind ...
 
 		   See https://hub.docker.com/_/docker/ for more documentation and usage examples.
 


### PR DESCRIPTION
This removes the no-longer-necessary explicit `overlay` override and the no-longer-recommended "stable" tag.