### PR TITLE
split tls-generate-certs.sh from dockerd-entrypoint.sh

### DIFF
--- a/18.09-rc/dind/Dockerfile
+++ b/18.09-rc/dind/Dockerfile
@@ -36,6 +36,7 @@ RUN set -eux; \
 	wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind"; \
 	chmod +x /usr/local/bin/dind
 
+COPY tls-generate-certs.sh /usr/local/bin/
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 VOLUME /var/lib/docker

--- a/18.09-rc/dind/dockerd-entrypoint.sh
+++ b/18.09-rc/dind/dockerd-entrypoint.sh
@@ -1,100 +1,12 @@
 #!/bin/sh
 set -eu
 
-_tls_ensure_private() {
-	local f="$1"; shift
-	[ -s "$f" ] || openssl genrsa -out "$f" 4196
-}
-_tls_san() {
-	{
-		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
-		{
-			cat /etc/hostname
-			echo 'docker'
-			echo 'localhost'
-			hostname -f
-			hostname -s
-		} | sed 's/^/DNS:/'
-		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
-	} | sort -u | xargs printf '%s,' | sed "s/,\$//"
-}
-_tls_generate_certs() {
-	local dir="$1"; shift
-
-	# if ca/key.pem || !ca/cert.pem, generate CA public if necessary
-	# if ca/key.pem, generate server public
-	# if ca/key.pem, generate client public
-	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
-
-	# https://github.com/FiloSottile/mkcert/issues/174
-	local certValidDays='825'
-
-	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
-		# if we either have a CA private key or do *not* have a CA public key, then we should create/manage the CA
-		mkdir -p "$dir/ca"
-		_tls_ensure_private "$dir/ca/key.pem"
-		openssl req -new -key "$dir/ca/key.pem" \
-			-out "$dir/ca/cert.pem" \
-			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
-	fi
-
-	if [ -s "$dir/ca/key.pem" ]; then
-		# if we have a CA private key, we should create/manage a server key
-		mkdir -p "$dir/server"
-		_tls_ensure_private "$dir/server/key.pem"
-		openssl req -new -key "$dir/server/key.pem" \
-			-out "$dir/server/csr.pem" \
-			-subj '/CN=docker:dind server'
-		cat > "$dir/server/openssl.cnf" <<-EOF
-			[ x509_exts ]
-			subjectAltName = $(_tls_san)
-		EOF
-		openssl x509 -req \
-				-in "$dir/server/csr.pem" \
-				-CA "$dir/ca/cert.pem" \
-				-CAkey "$dir/ca/key.pem" \
-				-CAcreateserial \
-				-out "$dir/server/cert.pem" \
-				-days "$certValidDays" \
-				-extfile "$dir/server/openssl.cnf" \
-				-extensions x509_exts
-		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
-		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
-	fi
-
-	if [ -s "$dir/ca/key.pem" ]; then
-		# if we have a CA private key, we should create/manage a client key
-		mkdir -p "$dir/client"
-		_tls_ensure_private "$dir/client/key.pem"
-		chmod 0644 "$dir/client/key.pem" # openssl defaults to 0600 for the private key, but this one needs to be shared with arbitrary client contexts
-		openssl req -new \
-				-key "$dir/client/key.pem" \
-				-out "$dir/client/csr.pem" \
-				-subj '/CN=docker:dind client'
-		cat > "$dir/client/openssl.cnf" <<-'EOF'
-			[ x509_exts ]
-			extendedKeyUsage = clientAuth
-		EOF
-		openssl x509 -req \
-				-in "$dir/client/csr.pem" \
-				-CA "$dir/ca/cert.pem" \
-				-CAkey "$dir/ca/key.pem" \
-				-CAcreateserial \
-				-out "$dir/client/cert.pem" \
-				-days "$certValidDays" \
-				-extfile "$dir/client/openssl.cnf" \
-				-extensions x509_exts
-		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
-		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
-	fi
-}
-
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
 	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
-		&& _tls_generate_certs "$DOCKER_TLS_CERTDIR" \
+		&& tls-generate-certs.sh "$DOCKER_TLS_CERTDIR" \
 		&& [ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ] \
 		&& [ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ] \
 		&& [ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ] \

--- a/18.09-rc/dind/tls-generate-certs.sh
+++ b/18.09-rc/dind/tls-generate-certs.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+set -eu
+
+_tls_ensure_private() {
+	local f="$1"; shift
+	[ -s "$f" ] || openssl genrsa -out "$f" 4196
+}
+_tls_san() {
+	{
+		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
+		{
+			cat /etc/hostname
+			echo 'docker'
+			echo 'localhost'
+			hostname -f
+			hostname -s
+		} | sed 's/^/DNS:/'
+		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
+	} | sort -u | xargs printf '%s,' | sed "s/,\$//"
+}
+_tls_generate_certs() {
+	local dir="$1"; shift
+
+	# if ca/key.pem || !ca/cert.pem, generate CA public if necessary
+	# if ca/key.pem, generate server public
+	# if ca/key.pem, generate client public
+	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
+
+	# https://github.com/FiloSottile/mkcert/issues/174
+	local certValidDays='825'
+
+	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
+		# if we either have a CA private key or do *not* have a CA public key, then we should create/manage the CA
+		mkdir -p "$dir/ca"
+		_tls_ensure_private "$dir/ca/key.pem"
+		openssl req -new -key "$dir/ca/key.pem" \
+			-out "$dir/ca/cert.pem" \
+			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a server key
+		mkdir -p "$dir/server"
+		_tls_ensure_private "$dir/server/key.pem"
+		openssl req -new -key "$dir/server/key.pem" \
+			-out "$dir/server/csr.pem" \
+			-subj '/CN=docker:dind server'
+		cat > "$dir/server/openssl.cnf" <<-EOF
+			[ x509_exts ]
+			subjectAltName = $(_tls_san)
+		EOF
+		openssl x509 -req \
+				-in "$dir/server/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/server/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/server/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
+		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a client key
+		mkdir -p "$dir/client"
+		_tls_ensure_private "$dir/client/key.pem"
+		chmod 0644 "$dir/client/key.pem" # openssl defaults to 0600 for the private key, but this one needs to be shared with arbitrary client contexts
+		openssl req -new \
+				-key "$dir/client/key.pem" \
+				-out "$dir/client/csr.pem" \
+				-subj '/CN=docker:dind client'
+		cat > "$dir/client/openssl.cnf" <<-'EOF'
+			[ x509_exts ]
+			extendedKeyUsage = clientAuth
+		EOF
+		openssl x509 -req \
+				-in "$dir/client/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/client/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/client/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
+		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
+	fi
+}
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 DIR"
+    exit 1
+fi
+
+_tls_generate_certs $1
+

--- a/18.09/dind/Dockerfile
+++ b/18.09/dind/Dockerfile
@@ -36,6 +36,7 @@ RUN set -eux; \
 	wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind"; \
 	chmod +x /usr/local/bin/dind
 
+COPY tls-generate-certs.sh /usr/local/bin/
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 VOLUME /var/lib/docker

--- a/18.09/dind/dockerd-entrypoint.sh
+++ b/18.09/dind/dockerd-entrypoint.sh
@@ -1,100 +1,12 @@
 #!/bin/sh
 set -eu
 
-_tls_ensure_private() {
-	local f="$1"; shift
-	[ -s "$f" ] || openssl genrsa -out "$f" 4196
-}
-_tls_san() {
-	{
-		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
-		{
-			cat /etc/hostname
-			echo 'docker'
-			echo 'localhost'
-			hostname -f
-			hostname -s
-		} | sed 's/^/DNS:/'
-		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
-	} | sort -u | xargs printf '%s,' | sed "s/,\$//"
-}
-_tls_generate_certs() {
-	local dir="$1"; shift
-
-	# if ca/key.pem || !ca/cert.pem, generate CA public if necessary
-	# if ca/key.pem, generate server public
-	# if ca/key.pem, generate client public
-	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
-
-	# https://github.com/FiloSottile/mkcert/issues/174
-	local certValidDays='825'
-
-	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
-		# if we either have a CA private key or do *not* have a CA public key, then we should create/manage the CA
-		mkdir -p "$dir/ca"
-		_tls_ensure_private "$dir/ca/key.pem"
-		openssl req -new -key "$dir/ca/key.pem" \
-			-out "$dir/ca/cert.pem" \
-			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
-	fi
-
-	if [ -s "$dir/ca/key.pem" ]; then
-		# if we have a CA private key, we should create/manage a server key
-		mkdir -p "$dir/server"
-		_tls_ensure_private "$dir/server/key.pem"
-		openssl req -new -key "$dir/server/key.pem" \
-			-out "$dir/server/csr.pem" \
-			-subj '/CN=docker:dind server'
-		cat > "$dir/server/openssl.cnf" <<-EOF
-			[ x509_exts ]
-			subjectAltName = $(_tls_san)
-		EOF
-		openssl x509 -req \
-				-in "$dir/server/csr.pem" \
-				-CA "$dir/ca/cert.pem" \
-				-CAkey "$dir/ca/key.pem" \
-				-CAcreateserial \
-				-out "$dir/server/cert.pem" \
-				-days "$certValidDays" \
-				-extfile "$dir/server/openssl.cnf" \
-				-extensions x509_exts
-		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
-		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
-	fi
-
-	if [ -s "$dir/ca/key.pem" ]; then
-		# if we have a CA private key, we should create/manage a client key
-		mkdir -p "$dir/client"
-		_tls_ensure_private "$dir/client/key.pem"
-		chmod 0644 "$dir/client/key.pem" # openssl defaults to 0600 for the private key, but this one needs to be shared with arbitrary client contexts
-		openssl req -new \
-				-key "$dir/client/key.pem" \
-				-out "$dir/client/csr.pem" \
-				-subj '/CN=docker:dind client'
-		cat > "$dir/client/openssl.cnf" <<-'EOF'
-			[ x509_exts ]
-			extendedKeyUsage = clientAuth
-		EOF
-		openssl x509 -req \
-				-in "$dir/client/csr.pem" \
-				-CA "$dir/ca/cert.pem" \
-				-CAkey "$dir/ca/key.pem" \
-				-CAcreateserial \
-				-out "$dir/client/cert.pem" \
-				-days "$certValidDays" \
-				-extfile "$dir/client/openssl.cnf" \
-				-extensions x509_exts
-		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
-		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
-	fi
-}
-
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
 	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
-		&& _tls_generate_certs "$DOCKER_TLS_CERTDIR" \
+		&& tls-generate-certs.sh "$DOCKER_TLS_CERTDIR" \
 		&& [ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ] \
 		&& [ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ] \
 		&& [ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ] \

--- a/18.09/dind/tls-generate-certs.sh
+++ b/18.09/dind/tls-generate-certs.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+set -eu
+
+_tls_ensure_private() {
+	local f="$1"; shift
+	[ -s "$f" ] || openssl genrsa -out "$f" 4196
+}
+_tls_san() {
+	{
+		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
+		{
+			cat /etc/hostname
+			echo 'docker'
+			echo 'localhost'
+			hostname -f
+			hostname -s
+		} | sed 's/^/DNS:/'
+		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
+	} | sort -u | xargs printf '%s,' | sed "s/,\$//"
+}
+_tls_generate_certs() {
+	local dir="$1"; shift
+
+	# if ca/key.pem || !ca/cert.pem, generate CA public if necessary
+	# if ca/key.pem, generate server public
+	# if ca/key.pem, generate client public
+	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
+
+	# https://github.com/FiloSottile/mkcert/issues/174
+	local certValidDays='825'
+
+	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
+		# if we either have a CA private key or do *not* have a CA public key, then we should create/manage the CA
+		mkdir -p "$dir/ca"
+		_tls_ensure_private "$dir/ca/key.pem"
+		openssl req -new -key "$dir/ca/key.pem" \
+			-out "$dir/ca/cert.pem" \
+			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a server key
+		mkdir -p "$dir/server"
+		_tls_ensure_private "$dir/server/key.pem"
+		openssl req -new -key "$dir/server/key.pem" \
+			-out "$dir/server/csr.pem" \
+			-subj '/CN=docker:dind server'
+		cat > "$dir/server/openssl.cnf" <<-EOF
+			[ x509_exts ]
+			subjectAltName = $(_tls_san)
+		EOF
+		openssl x509 -req \
+				-in "$dir/server/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/server/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/server/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
+		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a client key
+		mkdir -p "$dir/client"
+		_tls_ensure_private "$dir/client/key.pem"
+		chmod 0644 "$dir/client/key.pem" # openssl defaults to 0600 for the private key, but this one needs to be shared with arbitrary client contexts
+		openssl req -new \
+				-key "$dir/client/key.pem" \
+				-out "$dir/client/csr.pem" \
+				-subj '/CN=docker:dind client'
+		cat > "$dir/client/openssl.cnf" <<-'EOF'
+			[ x509_exts ]
+			extendedKeyUsage = clientAuth
+		EOF
+		openssl x509 -req \
+				-in "$dir/client/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/client/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/client/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
+		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
+	fi
+}
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 DIR"
+    exit 1
+fi
+
+_tls_generate_certs $1
+

--- a/19.03-rc/dind/Dockerfile
+++ b/19.03-rc/dind/Dockerfile
@@ -36,6 +36,7 @@ RUN set -eux; \
 	wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind"; \
 	chmod +x /usr/local/bin/dind
 
+COPY tls-generate-certs.sh /usr/local/bin/
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 VOLUME /var/lib/docker

--- a/19.03-rc/dind/dockerd-entrypoint.sh
+++ b/19.03-rc/dind/dockerd-entrypoint.sh
@@ -1,100 +1,12 @@
 #!/bin/sh
 set -eu
 
-_tls_ensure_private() {
-	local f="$1"; shift
-	[ -s "$f" ] || openssl genrsa -out "$f" 4196
-}
-_tls_san() {
-	{
-		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
-		{
-			cat /etc/hostname
-			echo 'docker'
-			echo 'localhost'
-			hostname -f
-			hostname -s
-		} | sed 's/^/DNS:/'
-		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
-	} | sort -u | xargs printf '%s,' | sed "s/,\$//"
-}
-_tls_generate_certs() {
-	local dir="$1"; shift
-
-	# if ca/key.pem || !ca/cert.pem, generate CA public if necessary
-	# if ca/key.pem, generate server public
-	# if ca/key.pem, generate client public
-	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
-
-	# https://github.com/FiloSottile/mkcert/issues/174
-	local certValidDays='825'
-
-	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
-		# if we either have a CA private key or do *not* have a CA public key, then we should create/manage the CA
-		mkdir -p "$dir/ca"
-		_tls_ensure_private "$dir/ca/key.pem"
-		openssl req -new -key "$dir/ca/key.pem" \
-			-out "$dir/ca/cert.pem" \
-			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
-	fi
-
-	if [ -s "$dir/ca/key.pem" ]; then
-		# if we have a CA private key, we should create/manage a server key
-		mkdir -p "$dir/server"
-		_tls_ensure_private "$dir/server/key.pem"
-		openssl req -new -key "$dir/server/key.pem" \
-			-out "$dir/server/csr.pem" \
-			-subj '/CN=docker:dind server'
-		cat > "$dir/server/openssl.cnf" <<-EOF
-			[ x509_exts ]
-			subjectAltName = $(_tls_san)
-		EOF
-		openssl x509 -req \
-				-in "$dir/server/csr.pem" \
-				-CA "$dir/ca/cert.pem" \
-				-CAkey "$dir/ca/key.pem" \
-				-CAcreateserial \
-				-out "$dir/server/cert.pem" \
-				-days "$certValidDays" \
-				-extfile "$dir/server/openssl.cnf" \
-				-extensions x509_exts
-		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
-		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
-	fi
-
-	if [ -s "$dir/ca/key.pem" ]; then
-		# if we have a CA private key, we should create/manage a client key
-		mkdir -p "$dir/client"
-		_tls_ensure_private "$dir/client/key.pem"
-		chmod 0644 "$dir/client/key.pem" # openssl defaults to 0600 for the private key, but this one needs to be shared with arbitrary client contexts
-		openssl req -new \
-				-key "$dir/client/key.pem" \
-				-out "$dir/client/csr.pem" \
-				-subj '/CN=docker:dind client'
-		cat > "$dir/client/openssl.cnf" <<-'EOF'
-			[ x509_exts ]
-			extendedKeyUsage = clientAuth
-		EOF
-		openssl x509 -req \
-				-in "$dir/client/csr.pem" \
-				-CA "$dir/ca/cert.pem" \
-				-CAkey "$dir/ca/key.pem" \
-				-CAcreateserial \
-				-out "$dir/client/cert.pem" \
-				-days "$certValidDays" \
-				-extfile "$dir/client/openssl.cnf" \
-				-extensions x509_exts
-		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
-		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
-	fi
-}
-
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
 	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
-		&& _tls_generate_certs "$DOCKER_TLS_CERTDIR" \
+		&& tls-generate-certs.sh "$DOCKER_TLS_CERTDIR" \
 		&& [ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ] \
 		&& [ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ] \
 		&& [ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ] \

--- a/19.03-rc/dind/tls-generate-certs.sh
+++ b/19.03-rc/dind/tls-generate-certs.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+set -eu
+
+_tls_ensure_private() {
+	local f="$1"; shift
+	[ -s "$f" ] || openssl genrsa -out "$f" 4196
+}
+_tls_san() {
+	{
+		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
+		{
+			cat /etc/hostname
+			echo 'docker'
+			echo 'localhost'
+			hostname -f
+			hostname -s
+		} | sed 's/^/DNS:/'
+		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
+	} | sort -u | xargs printf '%s,' | sed "s/,\$//"
+}
+_tls_generate_certs() {
+	local dir="$1"; shift
+
+	# if ca/key.pem || !ca/cert.pem, generate CA public if necessary
+	# if ca/key.pem, generate server public
+	# if ca/key.pem, generate client public
+	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
+
+	# https://github.com/FiloSottile/mkcert/issues/174
+	local certValidDays='825'
+
+	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
+		# if we either have a CA private key or do *not* have a CA public key, then we should create/manage the CA
+		mkdir -p "$dir/ca"
+		_tls_ensure_private "$dir/ca/key.pem"
+		openssl req -new -key "$dir/ca/key.pem" \
+			-out "$dir/ca/cert.pem" \
+			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a server key
+		mkdir -p "$dir/server"
+		_tls_ensure_private "$dir/server/key.pem"
+		openssl req -new -key "$dir/server/key.pem" \
+			-out "$dir/server/csr.pem" \
+			-subj '/CN=docker:dind server'
+		cat > "$dir/server/openssl.cnf" <<-EOF
+			[ x509_exts ]
+			subjectAltName = $(_tls_san)
+		EOF
+		openssl x509 -req \
+				-in "$dir/server/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/server/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/server/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
+		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a client key
+		mkdir -p "$dir/client"
+		_tls_ensure_private "$dir/client/key.pem"
+		chmod 0644 "$dir/client/key.pem" # openssl defaults to 0600 for the private key, but this one needs to be shared with arbitrary client contexts
+		openssl req -new \
+				-key "$dir/client/key.pem" \
+				-out "$dir/client/csr.pem" \
+				-subj '/CN=docker:dind client'
+		cat > "$dir/client/openssl.cnf" <<-'EOF'
+			[ x509_exts ]
+			extendedKeyUsage = clientAuth
+		EOF
+		openssl x509 -req \
+				-in "$dir/client/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/client/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/client/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
+		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
+	fi
+}
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 DIR"
+    exit 1
+fi
+
+_tls_generate_certs $1
+

--- a/19.03/dind/Dockerfile
+++ b/19.03/dind/Dockerfile
@@ -36,6 +36,7 @@ RUN set -eux; \
 	wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind"; \
 	chmod +x /usr/local/bin/dind
 
+COPY tls-generate-certs.sh /usr/local/bin/
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 VOLUME /var/lib/docker

--- a/19.03/dind/dockerd-entrypoint.sh
+++ b/19.03/dind/dockerd-entrypoint.sh
@@ -1,100 +1,12 @@
 #!/bin/sh
 set -eu
 
-_tls_ensure_private() {
-	local f="$1"; shift
-	[ -s "$f" ] || openssl genrsa -out "$f" 4196
-}
-_tls_san() {
-	{
-		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
-		{
-			cat /etc/hostname
-			echo 'docker'
-			echo 'localhost'
-			hostname -f
-			hostname -s
-		} | sed 's/^/DNS:/'
-		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
-	} | sort -u | xargs printf '%s,' | sed "s/,\$//"
-}
-_tls_generate_certs() {
-	local dir="$1"; shift
-
-	# if ca/key.pem || !ca/cert.pem, generate CA public if necessary
-	# if ca/key.pem, generate server public
-	# if ca/key.pem, generate client public
-	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
-
-	# https://github.com/FiloSottile/mkcert/issues/174
-	local certValidDays='825'
-
-	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
-		# if we either have a CA private key or do *not* have a CA public key, then we should create/manage the CA
-		mkdir -p "$dir/ca"
-		_tls_ensure_private "$dir/ca/key.pem"
-		openssl req -new -key "$dir/ca/key.pem" \
-			-out "$dir/ca/cert.pem" \
-			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
-	fi
-
-	if [ -s "$dir/ca/key.pem" ]; then
-		# if we have a CA private key, we should create/manage a server key
-		mkdir -p "$dir/server"
-		_tls_ensure_private "$dir/server/key.pem"
-		openssl req -new -key "$dir/server/key.pem" \
-			-out "$dir/server/csr.pem" \
-			-subj '/CN=docker:dind server'
-		cat > "$dir/server/openssl.cnf" <<-EOF
-			[ x509_exts ]
-			subjectAltName = $(_tls_san)
-		EOF
-		openssl x509 -req \
-				-in "$dir/server/csr.pem" \
-				-CA "$dir/ca/cert.pem" \
-				-CAkey "$dir/ca/key.pem" \
-				-CAcreateserial \
-				-out "$dir/server/cert.pem" \
-				-days "$certValidDays" \
-				-extfile "$dir/server/openssl.cnf" \
-				-extensions x509_exts
-		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
-		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
-	fi
-
-	if [ -s "$dir/ca/key.pem" ]; then
-		# if we have a CA private key, we should create/manage a client key
-		mkdir -p "$dir/client"
-		_tls_ensure_private "$dir/client/key.pem"
-		chmod 0644 "$dir/client/key.pem" # openssl defaults to 0600 for the private key, but this one needs to be shared with arbitrary client contexts
-		openssl req -new \
-				-key "$dir/client/key.pem" \
-				-out "$dir/client/csr.pem" \
-				-subj '/CN=docker:dind client'
-		cat > "$dir/client/openssl.cnf" <<-'EOF'
-			[ x509_exts ]
-			extendedKeyUsage = clientAuth
-		EOF
-		openssl x509 -req \
-				-in "$dir/client/csr.pem" \
-				-CA "$dir/ca/cert.pem" \
-				-CAkey "$dir/ca/key.pem" \
-				-CAcreateserial \
-				-out "$dir/client/cert.pem" \
-				-days "$certValidDays" \
-				-extfile "$dir/client/openssl.cnf" \
-				-extensions x509_exts
-		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
-		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
-	fi
-}
-
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
 	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
-		&& _tls_generate_certs "$DOCKER_TLS_CERTDIR" \
+		&& tls-generate-certs.sh "$DOCKER_TLS_CERTDIR" \
 		&& [ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ] \
 		&& [ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ] \
 		&& [ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ] \

--- a/19.03/dind/tls-generate-certs.sh
+++ b/19.03/dind/tls-generate-certs.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+set -eu
+
+_tls_ensure_private() {
+	local f="$1"; shift
+	[ -s "$f" ] || openssl genrsa -out "$f" 4196
+}
+_tls_san() {
+	{
+		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
+		{
+			cat /etc/hostname
+			echo 'docker'
+			echo 'localhost'
+			hostname -f
+			hostname -s
+		} | sed 's/^/DNS:/'
+		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
+	} | sort -u | xargs printf '%s,' | sed "s/,\$//"
+}
+_tls_generate_certs() {
+	local dir="$1"; shift
+
+	# if ca/key.pem || !ca/cert.pem, generate CA public if necessary
+	# if ca/key.pem, generate server public
+	# if ca/key.pem, generate client public
+	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
+
+	# https://github.com/FiloSottile/mkcert/issues/174
+	local certValidDays='825'
+
+	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
+		# if we either have a CA private key or do *not* have a CA public key, then we should create/manage the CA
+		mkdir -p "$dir/ca"
+		_tls_ensure_private "$dir/ca/key.pem"
+		openssl req -new -key "$dir/ca/key.pem" \
+			-out "$dir/ca/cert.pem" \
+			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a server key
+		mkdir -p "$dir/server"
+		_tls_ensure_private "$dir/server/key.pem"
+		openssl req -new -key "$dir/server/key.pem" \
+			-out "$dir/server/csr.pem" \
+			-subj '/CN=docker:dind server'
+		cat > "$dir/server/openssl.cnf" <<-EOF
+			[ x509_exts ]
+			subjectAltName = $(_tls_san)
+		EOF
+		openssl x509 -req \
+				-in "$dir/server/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/server/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/server/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
+		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a client key
+		mkdir -p "$dir/client"
+		_tls_ensure_private "$dir/client/key.pem"
+		chmod 0644 "$dir/client/key.pem" # openssl defaults to 0600 for the private key, but this one needs to be shared with arbitrary client contexts
+		openssl req -new \
+				-key "$dir/client/key.pem" \
+				-out "$dir/client/csr.pem" \
+				-subj '/CN=docker:dind client'
+		cat > "$dir/client/openssl.cnf" <<-'EOF'
+			[ x509_exts ]
+			extendedKeyUsage = clientAuth
+		EOF
+		openssl x509 -req \
+				-in "$dir/client/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/client/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/client/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
+		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
+	fi
+}
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 DIR"
+    exit 1
+fi
+
+_tls_generate_certs $1
+

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -36,6 +36,7 @@ RUN set -eux; \
 	wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind"; \
 	chmod +x /usr/local/bin/dind
 
+COPY tls-generate-certs.sh /usr/local/bin/
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 VOLUME /var/lib/docker

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -1,100 +1,12 @@
 #!/bin/sh
 set -eu
 
-_tls_ensure_private() {
-	local f="$1"; shift
-	[ -s "$f" ] || openssl genrsa -out "$f" 4196
-}
-_tls_san() {
-	{
-		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
-		{
-			cat /etc/hostname
-			echo 'docker'
-			echo 'localhost'
-			hostname -f
-			hostname -s
-		} | sed 's/^/DNS:/'
-		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
-	} | sort -u | xargs printf '%s,' | sed "s/,\$//"
-}
-_tls_generate_certs() {
-	local dir="$1"; shift
-
-	# if ca/key.pem || !ca/cert.pem, generate CA public if necessary
-	# if ca/key.pem, generate server public
-	# if ca/key.pem, generate client public
-	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
-
-	# https://github.com/FiloSottile/mkcert/issues/174
-	local certValidDays='825'
-
-	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
-		# if we either have a CA private key or do *not* have a CA public key, then we should create/manage the CA
-		mkdir -p "$dir/ca"
-		_tls_ensure_private "$dir/ca/key.pem"
-		openssl req -new -key "$dir/ca/key.pem" \
-			-out "$dir/ca/cert.pem" \
-			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
-	fi
-
-	if [ -s "$dir/ca/key.pem" ]; then
-		# if we have a CA private key, we should create/manage a server key
-		mkdir -p "$dir/server"
-		_tls_ensure_private "$dir/server/key.pem"
-		openssl req -new -key "$dir/server/key.pem" \
-			-out "$dir/server/csr.pem" \
-			-subj '/CN=docker:dind server'
-		cat > "$dir/server/openssl.cnf" <<-EOF
-			[ x509_exts ]
-			subjectAltName = $(_tls_san)
-		EOF
-		openssl x509 -req \
-				-in "$dir/server/csr.pem" \
-				-CA "$dir/ca/cert.pem" \
-				-CAkey "$dir/ca/key.pem" \
-				-CAcreateserial \
-				-out "$dir/server/cert.pem" \
-				-days "$certValidDays" \
-				-extfile "$dir/server/openssl.cnf" \
-				-extensions x509_exts
-		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
-		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
-	fi
-
-	if [ -s "$dir/ca/key.pem" ]; then
-		# if we have a CA private key, we should create/manage a client key
-		mkdir -p "$dir/client"
-		_tls_ensure_private "$dir/client/key.pem"
-		chmod 0644 "$dir/client/key.pem" # openssl defaults to 0600 for the private key, but this one needs to be shared with arbitrary client contexts
-		openssl req -new \
-				-key "$dir/client/key.pem" \
-				-out "$dir/client/csr.pem" \
-				-subj '/CN=docker:dind client'
-		cat > "$dir/client/openssl.cnf" <<-'EOF'
-			[ x509_exts ]
-			extendedKeyUsage = clientAuth
-		EOF
-		openssl x509 -req \
-				-in "$dir/client/csr.pem" \
-				-CA "$dir/ca/cert.pem" \
-				-CAkey "$dir/ca/key.pem" \
-				-CAcreateserial \
-				-out "$dir/client/cert.pem" \
-				-days "$certValidDays" \
-				-extfile "$dir/client/openssl.cnf" \
-				-extensions x509_exts
-		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
-		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
-	fi
-}
-
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	# add our default arguments
 	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
-		&& _tls_generate_certs "$DOCKER_TLS_CERTDIR" \
+		&& tls-generate-certs.sh "$DOCKER_TLS_CERTDIR" \
 		&& [ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ] \
 		&& [ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ] \
 		&& [ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ] \

--- a/tls-generate-certs.sh
+++ b/tls-generate-certs.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+set -eu
+
+_tls_ensure_private() {
+	local f="$1"; shift
+	[ -s "$f" ] || openssl genrsa -out "$f" 4196
+}
+_tls_san() {
+	{
+		ip -oneline address | awk '{ gsub(/\/.+$/, "", $4); print "IP:" $4 }'
+		{
+			cat /etc/hostname
+			echo 'docker'
+			echo 'localhost'
+			hostname -f
+			hostname -s
+		} | sed 's/^/DNS:/'
+		[ -z "${DOCKER_TLS_SAN:-}" ] || echo "$DOCKER_TLS_SAN"
+	} | sort -u | xargs printf '%s,' | sed "s/,\$//"
+}
+_tls_generate_certs() {
+	local dir="$1"; shift
+
+	# if ca/key.pem || !ca/cert.pem, generate CA public if necessary
+	# if ca/key.pem, generate server public
+	# if ca/key.pem, generate client public
+	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
+
+	# https://github.com/FiloSottile/mkcert/issues/174
+	local certValidDays='825'
+
+	if [ -s "$dir/ca/key.pem" ] || [ ! -s "$dir/ca/cert.pem" ]; then
+		# if we either have a CA private key or do *not* have a CA public key, then we should create/manage the CA
+		mkdir -p "$dir/ca"
+		_tls_ensure_private "$dir/ca/key.pem"
+		openssl req -new -key "$dir/ca/key.pem" \
+			-out "$dir/ca/cert.pem" \
+			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a server key
+		mkdir -p "$dir/server"
+		_tls_ensure_private "$dir/server/key.pem"
+		openssl req -new -key "$dir/server/key.pem" \
+			-out "$dir/server/csr.pem" \
+			-subj '/CN=docker:dind server'
+		cat > "$dir/server/openssl.cnf" <<-EOF
+			[ x509_exts ]
+			subjectAltName = $(_tls_san)
+		EOF
+		openssl x509 -req \
+				-in "$dir/server/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/server/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/server/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/server/ca.pem"
+		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
+	fi
+
+	if [ -s "$dir/ca/key.pem" ]; then
+		# if we have a CA private key, we should create/manage a client key
+		mkdir -p "$dir/client"
+		_tls_ensure_private "$dir/client/key.pem"
+		chmod 0644 "$dir/client/key.pem" # openssl defaults to 0600 for the private key, but this one needs to be shared with arbitrary client contexts
+		openssl req -new \
+				-key "$dir/client/key.pem" \
+				-out "$dir/client/csr.pem" \
+				-subj '/CN=docker:dind client'
+		cat > "$dir/client/openssl.cnf" <<-'EOF'
+			[ x509_exts ]
+			extendedKeyUsage = clientAuth
+		EOF
+		openssl x509 -req \
+				-in "$dir/client/csr.pem" \
+				-CA "$dir/ca/cert.pem" \
+				-CAkey "$dir/ca/key.pem" \
+				-CAcreateserial \
+				-out "$dir/client/cert.pem" \
+				-days "$certValidDays" \
+				-extfile "$dir/client/openssl.cnf" \
+				-extensions x509_exts
+		cp "$dir/ca/cert.pem" "$dir/client/ca.pem"
+		openssl verify -CAfile "$dir/client/ca.pem" "$dir/client/cert.pem"
+	fi
+}
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 DIR"
+    exit 1
+fi
+
+_tls_generate_certs $1
+

--- a/update.sh
+++ b/update.sh
@@ -149,6 +149,7 @@ for version in "${versions[@]}"; do
 
 	cp -a docker-entrypoint.sh modprobe.sh "$version/"
 	cp -a dockerd-entrypoint.sh "$version/dind/"
+	cp -a tls-generate-certs.sh "$version/dind/"
 
 	travisEnv='\n  - VERSION='"$version$travisEnv"
 done


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>

so that it can be called from dind-rootless (#165) entrypoint script


