### PR TITLE
Remove EXPOSE completely

### DIFF
--- a/18.09-rc/dind/Dockerfile
+++ b/18.09-rc/dind/Dockerfile
@@ -39,7 +39,10 @@ RUN set -eux; \
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 VOLUME /var/lib/docker
-EXPOSE 2375 2376
+
+# TODO figure out why folks are using EXPOSE for health checks (https://gitlab.com/gitlab-org/gitlab-runner/issues/4501#note_194904002)
+#EXPOSE 2375 2376
+# (just because a port is listed under EXPOSE does not mean it will actually be listened on)
 
 ENTRYPOINT ["dockerd-entrypoint.sh"]
 CMD []

--- a/18.09/dind/Dockerfile
+++ b/18.09/dind/Dockerfile
@@ -39,7 +39,10 @@ RUN set -eux; \
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 VOLUME /var/lib/docker
-EXPOSE 2375 2376
+
+# TODO figure out why folks are using EXPOSE for health checks (https://gitlab.com/gitlab-org/gitlab-runner/issues/4501#note_194904002)
+#EXPOSE 2375 2376
+# (just because a port is listed under EXPOSE does not mean it will actually be listened on)
 
 ENTRYPOINT ["dockerd-entrypoint.sh"]
 CMD []

--- a/19.03-rc/dind/Dockerfile
+++ b/19.03-rc/dind/Dockerfile
@@ -39,7 +39,10 @@ RUN set -eux; \
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 VOLUME /var/lib/docker
-EXPOSE 2375 2376
+
+# TODO figure out why folks are using EXPOSE for health checks (https://gitlab.com/gitlab-org/gitlab-runner/issues/4501#note_194904002)
+#EXPOSE 2375 2376
+# (just because a port is listed under EXPOSE does not mean it will actually be listened on)
 
 ENTRYPOINT ["dockerd-entrypoint.sh"]
 CMD []

--- a/19.03/dind/Dockerfile
+++ b/19.03/dind/Dockerfile
@@ -39,7 +39,10 @@ RUN set -eux; \
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 VOLUME /var/lib/docker
-EXPOSE 2375 2376
+
+# TODO figure out why folks are using EXPOSE for health checks (https://gitlab.com/gitlab-org/gitlab-runner/issues/4501#note_194904002)
+#EXPOSE 2375 2376
+# (just because a port is listed under EXPOSE does not mean it will actually be listened on)
 
 ENTRYPOINT ["dockerd-entrypoint.sh"]
 CMD []

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -39,7 +39,10 @@ RUN set -eux; \
 COPY dockerd-entrypoint.sh /usr/local/bin/
 
 VOLUME /var/lib/docker
-EXPOSE 2375 2376
+
+# TODO figure out why folks are using EXPOSE for health checks (https://gitlab.com/gitlab-org/gitlab-runner/issues/4501#note_194904002)
+#EXPOSE 2375 2376
+# (just because a port is listed under EXPOSE does not mean it will actually be listened on)
 
 ENTRYPOINT ["dockerd-entrypoint.sh"]
 CMD []


### PR DESCRIPTION
Hopefully this is temporary -- apparently folks are using `EXPOSE` as a rough guide for doing healthchecks? (https://gitlab.com/gitlab-org/gitlab-runner/issues/4501#note_194904002)