### PR TITLE
Rename variable used for defining used docker.sock file

### DIFF
--- a/18.09-rc/dind/dockerd-entrypoint.sh
+++ b/18.09-rc/dind/dockerd-entrypoint.sh
@@ -92,16 +92,16 @@ _tls_generate_certs() {
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
-	# set DOCKER_HOST to the default "--host" value (for both standard or rootless)
+	# set DOCKER_SOCKET to the default "--host" value (for both standard or rootless)
 	uid="$(id -u)"
 	if [ "$uid" = '0' ]; then
-		: "${DOCKER_HOST:=unix:///var/run/docker.sock}"
+		: "${DOCKER_SOCKET:=unix:///var/run/docker.sock}"
 	else
 		# if we're not root, we must be trying to run rootless
 		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
-		: "${DOCKER_HOST:=unix://$XDG_RUNTIME_DIR/docker.sock}"
+		: "${DOCKER_SOCKET:=unix://$XDG_RUNTIME_DIR/docker.sock}"
 	fi
-	export DOCKER_HOST
+	export DOCKER_SOCKET
 
 	# add our default arguments
 	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
@@ -112,7 +112,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	; then
 		# generate certs and use TLS if requested/possible (default in 19.03+)
 		set -- dockerd \
-			--host="$DOCKER_HOST" \
+			--host="$DOCKER_SOCKET" \
 			--host=tcp://0.0.0.0:2376 \
 			--tlsverify \
 			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
@@ -123,7 +123,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	else
 		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
 		set -- dockerd \
-			--host="$DOCKER_HOST" \
+			--host="$DOCKER_SOCKET" \
 			--host=tcp://0.0.0.0:2375 \
 			"$@"
 		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"

--- a/18.09-rc/dind/dockerd-entrypoint.sh
+++ b/18.09-rc/dind/dockerd-entrypoint.sh
@@ -92,16 +92,20 @@ _tls_generate_certs() {
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
-	# set DOCKER_SOCKET to the default "--host" value (for both standard or rootless)
+	# set "dockerSocket" to the default "--host" *unix socket* value (for both standard or rootless)
 	uid="$(id -u)"
 	if [ "$uid" = '0' ]; then
-		: "${DOCKER_SOCKET:=unix:///var/run/docker.sock}"
+		dockerSocket='unix:///var/run/docker.sock'
 	else
 		# if we're not root, we must be trying to run rootless
 		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
-		: "${DOCKER_SOCKET:=unix://$XDG_RUNTIME_DIR/docker.sock}"
+		dockerSocket="unix://$XDG_RUNTIME_DIR/docker.sock"
 	fi
-	export DOCKER_SOCKET
+	case "${DOCKER_HOST:-}" in
+		unix://*)
+			dockerSocket="$DOCKER_HOST"
+			;;
+	esac
 
 	# add our default arguments
 	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
@@ -112,7 +116,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	; then
 		# generate certs and use TLS if requested/possible (default in 19.03+)
 		set -- dockerd \
-			--host="$DOCKER_SOCKET" \
+			--host="$dockerSocket" \
 			--host=tcp://0.0.0.0:2376 \
 			--tlsverify \
 			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
@@ -123,7 +127,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	else
 		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
 		set -- dockerd \
-			--host="$DOCKER_SOCKET" \
+			--host="$dockerSocket" \
 			--host=tcp://0.0.0.0:2375 \
 			"$@"
 		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"

--- a/18.09/dind/dockerd-entrypoint.sh
+++ b/18.09/dind/dockerd-entrypoint.sh
@@ -92,16 +92,16 @@ _tls_generate_certs() {
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
-	# set DOCKER_HOST to the default "--host" value (for both standard or rootless)
+	# set DOCKER_SOCKET to the default "--host" value (for both standard or rootless)
 	uid="$(id -u)"
 	if [ "$uid" = '0' ]; then
-		: "${DOCKER_HOST:=unix:///var/run/docker.sock}"
+		: "${DOCKER_SOCKET:=unix:///var/run/docker.sock}"
 	else
 		# if we're not root, we must be trying to run rootless
 		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
-		: "${DOCKER_HOST:=unix://$XDG_RUNTIME_DIR/docker.sock}"
+		: "${DOCKER_SOCKET:=unix://$XDG_RUNTIME_DIR/docker.sock}"
 	fi
-	export DOCKER_HOST
+	export DOCKER_SOCKET
 
 	# add our default arguments
 	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
@@ -112,7 +112,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	; then
 		# generate certs and use TLS if requested/possible (default in 19.03+)
 		set -- dockerd \
-			--host="$DOCKER_HOST" \
+			--host="$DOCKER_SOCKET" \
 			--host=tcp://0.0.0.0:2376 \
 			--tlsverify \
 			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
@@ -123,7 +123,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	else
 		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
 		set -- dockerd \
-			--host="$DOCKER_HOST" \
+			--host="$DOCKER_SOCKET" \
 			--host=tcp://0.0.0.0:2375 \
 			"$@"
 		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"

--- a/18.09/dind/dockerd-entrypoint.sh
+++ b/18.09/dind/dockerd-entrypoint.sh
@@ -92,16 +92,20 @@ _tls_generate_certs() {
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
-	# set DOCKER_SOCKET to the default "--host" value (for both standard or rootless)
+	# set "dockerSocket" to the default "--host" *unix socket* value (for both standard or rootless)
 	uid="$(id -u)"
 	if [ "$uid" = '0' ]; then
-		: "${DOCKER_SOCKET:=unix:///var/run/docker.sock}"
+		dockerSocket='unix:///var/run/docker.sock'
 	else
 		# if we're not root, we must be trying to run rootless
 		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
-		: "${DOCKER_SOCKET:=unix://$XDG_RUNTIME_DIR/docker.sock}"
+		dockerSocket="unix://$XDG_RUNTIME_DIR/docker.sock"
 	fi
-	export DOCKER_SOCKET
+	case "${DOCKER_HOST:-}" in
+		unix://*)
+			dockerSocket="$DOCKER_HOST"
+			;;
+	esac
 
 	# add our default arguments
 	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
@@ -112,7 +116,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	; then
 		# generate certs and use TLS if requested/possible (default in 19.03+)
 		set -- dockerd \
-			--host="$DOCKER_SOCKET" \
+			--host="$dockerSocket" \
 			--host=tcp://0.0.0.0:2376 \
 			--tlsverify \
 			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
@@ -123,7 +127,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	else
 		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
 		set -- dockerd \
-			--host="$DOCKER_SOCKET" \
+			--host="$dockerSocket" \
 			--host=tcp://0.0.0.0:2375 \
 			"$@"
 		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"

--- a/19.03-rc/dind/dockerd-entrypoint.sh
+++ b/19.03-rc/dind/dockerd-entrypoint.sh
@@ -92,16 +92,16 @@ _tls_generate_certs() {
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
-	# set DOCKER_HOST to the default "--host" value (for both standard or rootless)
+	# set DOCKER_SOCKET to the default "--host" value (for both standard or rootless)
 	uid="$(id -u)"
 	if [ "$uid" = '0' ]; then
-		: "${DOCKER_HOST:=unix:///var/run/docker.sock}"
+		: "${DOCKER_SOCKET:=unix:///var/run/docker.sock}"
 	else
 		# if we're not root, we must be trying to run rootless
 		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
-		: "${DOCKER_HOST:=unix://$XDG_RUNTIME_DIR/docker.sock}"
+		: "${DOCKER_SOCKET:=unix://$XDG_RUNTIME_DIR/docker.sock}"
 	fi
-	export DOCKER_HOST
+	export DOCKER_SOCKET
 
 	# add our default arguments
 	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
@@ -112,7 +112,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	; then
 		# generate certs and use TLS if requested/possible (default in 19.03+)
 		set -- dockerd \
-			--host="$DOCKER_HOST" \
+			--host="$DOCKER_SOCKET" \
 			--host=tcp://0.0.0.0:2376 \
 			--tlsverify \
 			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
@@ -123,7 +123,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	else
 		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
 		set -- dockerd \
-			--host="$DOCKER_HOST" \
+			--host="$DOCKER_SOCKET" \
 			--host=tcp://0.0.0.0:2375 \
 			"$@"
 		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"

--- a/19.03-rc/dind/dockerd-entrypoint.sh
+++ b/19.03-rc/dind/dockerd-entrypoint.sh
@@ -92,16 +92,20 @@ _tls_generate_certs() {
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
-	# set DOCKER_SOCKET to the default "--host" value (for both standard or rootless)
+	# set "dockerSocket" to the default "--host" *unix socket* value (for both standard or rootless)
 	uid="$(id -u)"
 	if [ "$uid" = '0' ]; then
-		: "${DOCKER_SOCKET:=unix:///var/run/docker.sock}"
+		dockerSocket='unix:///var/run/docker.sock'
 	else
 		# if we're not root, we must be trying to run rootless
 		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
-		: "${DOCKER_SOCKET:=unix://$XDG_RUNTIME_DIR/docker.sock}"
+		dockerSocket="unix://$XDG_RUNTIME_DIR/docker.sock"
 	fi
-	export DOCKER_SOCKET
+	case "${DOCKER_HOST:-}" in
+		unix://*)
+			dockerSocket="$DOCKER_HOST"
+			;;
+	esac
 
 	# add our default arguments
 	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
@@ -112,7 +116,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	; then
 		# generate certs and use TLS if requested/possible (default in 19.03+)
 		set -- dockerd \
-			--host="$DOCKER_SOCKET" \
+			--host="$dockerSocket" \
 			--host=tcp://0.0.0.0:2376 \
 			--tlsverify \
 			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
@@ -123,7 +127,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	else
 		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
 		set -- dockerd \
-			--host="$DOCKER_SOCKET" \
+			--host="$dockerSocket" \
 			--host=tcp://0.0.0.0:2375 \
 			"$@"
 		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"

--- a/19.03/dind/dockerd-entrypoint.sh
+++ b/19.03/dind/dockerd-entrypoint.sh
@@ -92,16 +92,16 @@ _tls_generate_certs() {
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
-	# set DOCKER_HOST to the default "--host" value (for both standard or rootless)
+	# set DOCKER_SOCKET to the default "--host" value (for both standard or rootless)
 	uid="$(id -u)"
 	if [ "$uid" = '0' ]; then
-		: "${DOCKER_HOST:=unix:///var/run/docker.sock}"
+		: "${DOCKER_SOCKET:=unix:///var/run/docker.sock}"
 	else
 		# if we're not root, we must be trying to run rootless
 		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
-		: "${DOCKER_HOST:=unix://$XDG_RUNTIME_DIR/docker.sock}"
+		: "${DOCKER_SOCKET:=unix://$XDG_RUNTIME_DIR/docker.sock}"
 	fi
-	export DOCKER_HOST
+	export DOCKER_SOCKET
 
 	# add our default arguments
 	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
@@ -112,7 +112,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	; then
 		# generate certs and use TLS if requested/possible (default in 19.03+)
 		set -- dockerd \
-			--host="$DOCKER_HOST" \
+			--host="$DOCKER_SOCKET" \
 			--host=tcp://0.0.0.0:2376 \
 			--tlsverify \
 			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
@@ -123,7 +123,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	else
 		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
 		set -- dockerd \
-			--host="$DOCKER_HOST" \
+			--host="$DOCKER_SOCKET" \
 			--host=tcp://0.0.0.0:2375 \
 			"$@"
 		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"

--- a/19.03/dind/dockerd-entrypoint.sh
+++ b/19.03/dind/dockerd-entrypoint.sh
@@ -92,16 +92,20 @@ _tls_generate_certs() {
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
-	# set DOCKER_SOCKET to the default "--host" value (for both standard or rootless)
+	# set "dockerSocket" to the default "--host" *unix socket* value (for both standard or rootless)
 	uid="$(id -u)"
 	if [ "$uid" = '0' ]; then
-		: "${DOCKER_SOCKET:=unix:///var/run/docker.sock}"
+		dockerSocket='unix:///var/run/docker.sock'
 	else
 		# if we're not root, we must be trying to run rootless
 		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
-		: "${DOCKER_SOCKET:=unix://$XDG_RUNTIME_DIR/docker.sock}"
+		dockerSocket="unix://$XDG_RUNTIME_DIR/docker.sock"
 	fi
-	export DOCKER_SOCKET
+	case "${DOCKER_HOST:-}" in
+		unix://*)
+			dockerSocket="$DOCKER_HOST"
+			;;
+	esac
 
 	# add our default arguments
 	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
@@ -112,7 +116,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	; then
 		# generate certs and use TLS if requested/possible (default in 19.03+)
 		set -- dockerd \
-			--host="$DOCKER_SOCKET" \
+			--host="$dockerSocket" \
 			--host=tcp://0.0.0.0:2376 \
 			--tlsverify \
 			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
@@ -123,7 +127,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	else
 		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
 		set -- dockerd \
-			--host="$DOCKER_SOCKET" \
+			--host="$dockerSocket" \
 			--host=tcp://0.0.0.0:2375 \
 			"$@"
 		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -92,16 +92,16 @@ _tls_generate_certs() {
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
-	# set DOCKER_HOST to the default "--host" value (for both standard or rootless)
+	# set DOCKER_SOCKET to the default "--host" value (for both standard or rootless)
 	uid="$(id -u)"
 	if [ "$uid" = '0' ]; then
-		: "${DOCKER_HOST:=unix:///var/run/docker.sock}"
+		: "${DOCKER_SOCKET:=unix:///var/run/docker.sock}"
 	else
 		# if we're not root, we must be trying to run rootless
 		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
-		: "${DOCKER_HOST:=unix://$XDG_RUNTIME_DIR/docker.sock}"
+		: "${DOCKER_SOCKET:=unix://$XDG_RUNTIME_DIR/docker.sock}"
 	fi
-	export DOCKER_HOST
+	export DOCKER_SOCKET
 
 	# add our default arguments
 	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
@@ -112,7 +112,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	; then
 		# generate certs and use TLS if requested/possible (default in 19.03+)
 		set -- dockerd \
-			--host="$DOCKER_HOST" \
+			--host="$DOCKER_SOCKET" \
 			--host=tcp://0.0.0.0:2376 \
 			--tlsverify \
 			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
@@ -123,7 +123,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	else
 		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
 		set -- dockerd \
-			--host="$DOCKER_HOST" \
+			--host="$DOCKER_SOCKET" \
 			--host=tcp://0.0.0.0:2375 \
 			"$@"
 		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -92,16 +92,20 @@ _tls_generate_certs() {
 # no arguments passed
 # or first arg is `-f` or `--some-option`
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
-	# set DOCKER_SOCKET to the default "--host" value (for both standard or rootless)
+	# set "dockerSocket" to the default "--host" *unix socket* value (for both standard or rootless)
 	uid="$(id -u)"
 	if [ "$uid" = '0' ]; then
-		: "${DOCKER_SOCKET:=unix:///var/run/docker.sock}"
+		dockerSocket='unix:///var/run/docker.sock'
 	else
 		# if we're not root, we must be trying to run rootless
 		: "${XDG_RUNTIME_DIR:=/run/user/$uid}"
-		: "${DOCKER_SOCKET:=unix://$XDG_RUNTIME_DIR/docker.sock}"
+		dockerSocket="unix://$XDG_RUNTIME_DIR/docker.sock"
 	fi
-	export DOCKER_SOCKET
+	case "${DOCKER_HOST:-}" in
+		unix://*)
+			dockerSocket="$DOCKER_HOST"
+			;;
+	esac
 
 	# add our default arguments
 	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
@@ -112,7 +116,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	; then
 		# generate certs and use TLS if requested/possible (default in 19.03+)
 		set -- dockerd \
-			--host="$DOCKER_SOCKET" \
+			--host="$dockerSocket" \
 			--host=tcp://0.0.0.0:2376 \
 			--tlsverify \
 			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
@@ -123,7 +127,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	else
 		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
 		set -- dockerd \
-			--host="$DOCKER_SOCKET" \
+			--host="$dockerSocket" \
 			--host=tcp://0.0.0.0:2375 \
 			"$@"
 		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"


### PR DESCRIPTION
https://github.com/docker-library/docker/pull/174 added an experimental "rootless" variant of the DinD service.

While the change itself is simple and should not affect current usages, a `DOCKER_HOST` variable was used to define which docker.sock path should be used depending on the process owner's ID.

Chosing DOCKER_HOST variable for this is unfortunately not the best option:

1. It's not the best semantic choice - the code that uses it defines a socket file, not the host. DOCKER_SOCKET just seems to fit better the purpose.

1. DOCKER_HOST is already a variable, that is used by users to define where the Docker daemon is listening. In case when it's added to the DinD container (which is a common situation for example for GitLab CI jobs that are using DinD as a service), it finally ends with assigning two times the same port, while once it uses 0.0.0.0 address, and once some unresolvable domain name (depending on what user defined; most probably `docker`).

This commit proposes a change of the variable name to DOCKER_SOCKET, which will better match it purpose and additionally it will stop breaking configurations of many of docker:dind image users.

Fixes #175