### PR TITLE
Restrict channel aliases to 19.03

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -122,12 +122,12 @@ for version in "${versions[@]}"; do
 		${aliases[$version]:-}
 	)
 	if [ -z "${latestChannelRelease[$channel]:-}" ]; then
-		versionAliases+=( "$channel" )
+		if [ "$rcVersion" = '19.03' ]; then versionAliases+=( "$channel" ); fi # 19.03 is the last release to include any "channel" aliases
 		latestChannelRelease[$channel]="$version"
 	fi
 	# every release goes into the "test" channel, so the biggest numbered release wins (RC or not)
 	if [ -z "${latestChannelRelease['test']:-}" ]; then
-		versionAliases+=( 'test' )
+		if [ "$rcVersion" = '19.03' ]; then versionAliases+=( 'test' ); fi # 19.03 is the last release to include any "channel" aliases
 		latestChannelRelease['test']="$version"
 	fi
 	if [ "$version" = "$rcVersion" ] && [ -z "${latestChannelRelease['latest']:-}" ]; then


### PR DESCRIPTION
This will remove the "test" and "stable" aliases for whatever major release comes after 19.03 (so once the next release comes out, "stable" will become a stale alias).

I'm not 100% sure this is the right answer, but the "stable" alias has definitely been a huge source of confusion very recently (and it doesn't have much meaning anymore anyways given the death of the "edge" channel).

Closes #178