### PR TITLE
Only apply "/usr/local/bin/dind" if we aren't rootless

### DIFF
--- a/18.09-rc/dind/dockerd-entrypoint.sh
+++ b/18.09-rc/dind/dockerd-entrypoint.sh
@@ -135,11 +135,6 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 fi
 
 if [ "$1" = 'dockerd' ]; then
-	if [ -x '/usr/local/bin/dind' ]; then
-		# if we have the (mostly defunct now) Docker-in-Docker wrapper script, use it
-		set -- '/usr/local/bin/dind' "$@"
-	fi
-
 	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
 	find /run /var/run -iname 'docker*.pid' -delete || :
 
@@ -178,6 +173,9 @@ if [ "$1" = 'dockerd' ]; then
 			--copy-up=/etc --copy-up=/run \
 			${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
 			"$@" --userland-proxy-path=rootlesskit-docker-proxy
+	elif [ -x '/usr/local/bin/dind' ]; then
+		# if we have the (mostly defunct now) Docker-in-Docker wrapper script, use it
+		set -- '/usr/local/bin/dind' "$@"
 	fi
 else
 	# if it isn't `dockerd` we're trying to run, pass it through `docker-entrypoint.sh` so it gets `DOCKER_HOST` set appropriately too

--- a/18.09/dind/dockerd-entrypoint.sh
+++ b/18.09/dind/dockerd-entrypoint.sh
@@ -135,11 +135,6 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 fi
 
 if [ "$1" = 'dockerd' ]; then
-	if [ -x '/usr/local/bin/dind' ]; then
-		# if we have the (mostly defunct now) Docker-in-Docker wrapper script, use it
-		set -- '/usr/local/bin/dind' "$@"
-	fi
-
 	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
 	find /run /var/run -iname 'docker*.pid' -delete || :
 
@@ -178,6 +173,9 @@ if [ "$1" = 'dockerd' ]; then
 			--copy-up=/etc --copy-up=/run \
 			${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
 			"$@" --userland-proxy-path=rootlesskit-docker-proxy
+	elif [ -x '/usr/local/bin/dind' ]; then
+		# if we have the (mostly defunct now) Docker-in-Docker wrapper script, use it
+		set -- '/usr/local/bin/dind' "$@"
 	fi
 else
 	# if it isn't `dockerd` we're trying to run, pass it through `docker-entrypoint.sh` so it gets `DOCKER_HOST` set appropriately too

--- a/19.03-rc/dind/dockerd-entrypoint.sh
+++ b/19.03-rc/dind/dockerd-entrypoint.sh
@@ -135,11 +135,6 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 fi
 
 if [ "$1" = 'dockerd' ]; then
-	if [ -x '/usr/local/bin/dind' ]; then
-		# if we have the (mostly defunct now) Docker-in-Docker wrapper script, use it
-		set -- '/usr/local/bin/dind' "$@"
-	fi
-
 	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
 	find /run /var/run -iname 'docker*.pid' -delete || :
 
@@ -178,6 +173,9 @@ if [ "$1" = 'dockerd' ]; then
 			--copy-up=/etc --copy-up=/run \
 			${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
 			"$@" --userland-proxy-path=rootlesskit-docker-proxy
+	elif [ -x '/usr/local/bin/dind' ]; then
+		# if we have the (mostly defunct now) Docker-in-Docker wrapper script, use it
+		set -- '/usr/local/bin/dind' "$@"
 	fi
 else
 	# if it isn't `dockerd` we're trying to run, pass it through `docker-entrypoint.sh` so it gets `DOCKER_HOST` set appropriately too

--- a/19.03/dind/dockerd-entrypoint.sh
+++ b/19.03/dind/dockerd-entrypoint.sh
@@ -135,11 +135,6 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 fi
 
 if [ "$1" = 'dockerd' ]; then
-	if [ -x '/usr/local/bin/dind' ]; then
-		# if we have the (mostly defunct now) Docker-in-Docker wrapper script, use it
-		set -- '/usr/local/bin/dind' "$@"
-	fi
-
 	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
 	find /run /var/run -iname 'docker*.pid' -delete || :
 
@@ -178,6 +173,9 @@ if [ "$1" = 'dockerd' ]; then
 			--copy-up=/etc --copy-up=/run \
 			${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
 			"$@" --userland-proxy-path=rootlesskit-docker-proxy
+	elif [ -x '/usr/local/bin/dind' ]; then
+		# if we have the (mostly defunct now) Docker-in-Docker wrapper script, use it
+		set -- '/usr/local/bin/dind' "$@"
 	fi
 else
 	# if it isn't `dockerd` we're trying to run, pass it through `docker-entrypoint.sh` so it gets `DOCKER_HOST` set appropriately too

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -135,11 +135,6 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 fi
 
 if [ "$1" = 'dockerd' ]; then
-	if [ -x '/usr/local/bin/dind' ]; then
-		# if we have the (mostly defunct now) Docker-in-Docker wrapper script, use it
-		set -- '/usr/local/bin/dind' "$@"
-	fi
-
 	# explicitly remove Docker's default PID file to ensure that it can start properly if it was stopped uncleanly (and thus didn't clean up the PID file)
 	find /run /var/run -iname 'docker*.pid' -delete || :
 
@@ -178,6 +173,9 @@ if [ "$1" = 'dockerd' ]; then
 			--copy-up=/etc --copy-up=/run \
 			${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
 			"$@" --userland-proxy-path=rootlesskit-docker-proxy
+	elif [ -x '/usr/local/bin/dind' ]; then
+		# if we have the (mostly defunct now) Docker-in-Docker wrapper script, use it
+		set -- '/usr/local/bin/dind' "$@"
 	fi
 else
 	# if it isn't `dockerd` we're trying to run, pass it through `docker-entrypoint.sh` so it gets `DOCKER_HOST` set appropriately too


### PR DESCRIPTION
The `/usr/local/bin/dind` script is only barely meaningful for the running-as-root case anymore and definitely holds no value for rootless. :+1:

(For repeated context, that script used to be what would set up `/sys/fs/cgroup` inside the container, but Docker itself has been doing so automatically in a reasonable way for a very long time now.)