### PR TITLE
update RootlessKit to v0.7.0

### DIFF
--- a/19.03-rc/dind-rootless/Dockerfile
+++ b/19.03-rc/dind-rootless/Dockerfile
@@ -47,7 +47,7 @@ RUN set -eux; \
 	vpnkit --version
 
 # https://github.com/rootless-containers/rootlesskit/releases
-ENV ROOTLESSKIT_VERSION 0.6.0
+ENV ROOTLESSKIT_VERSION 0.7.0
 
 RUN set -eux; \
 	apk add --no-cache --virtual .rootlesskit-build-deps \

--- a/19.03/dind-rootless/Dockerfile
+++ b/19.03/dind-rootless/Dockerfile
@@ -47,7 +47,7 @@ RUN set -eux; \
 	vpnkit --version
 
 # https://github.com/rootless-containers/rootlesskit/releases
-ENV ROOTLESSKIT_VERSION 0.6.0
+ENV ROOTLESSKIT_VERSION 0.7.0
 
 RUN set -eux; \
 	apk add --no-cache --virtual .rootlesskit-build-deps \

--- a/Dockerfile-dind-rootless.template
+++ b/Dockerfile-dind-rootless.template
@@ -36,7 +36,7 @@ RUN set -eux; \
 	vpnkit --version
 
 # https://github.com/rootless-containers/rootlesskit/releases
-ENV ROOTLESSKIT_VERSION 0.6.0
+ENV ROOTLESSKIT_VERSION 0.7.0
 
 RUN set -eux; \
 	apk add --no-cache --virtual .rootlesskit-build-deps \


### PR DESCRIPTION
Corresponds to Docker v19.03.5

https://github.com/docker/engine/blob/v19.03.5/hack/dockerfile/install/rootlesskit.installer

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>