### PR TITLE
Add "openssh-client" to the standard client images

### DIFF
--- a/19.03-rc/Dockerfile
+++ b/19.03-rc/Dockerfile
@@ -1,7 +1,9 @@
 FROM alpine:3.10
 
 RUN apk add --no-cache \
-		ca-certificates
+		ca-certificates \
+# DOCKER_HOST=ssh://... -- https://github.com/docker/cli/pull/1014
+		openssh-client
 
 # set up nsswitch.conf for Go's "netgo" implementation (which Docker explicitly uses)
 # - https://github.com/docker/docker-ce/blob/v17.09.0-ce/components/engine/hack/make.sh#L149

--- a/19.03-rc/git/Dockerfile
+++ b/19.03-rc/git/Dockerfile
@@ -1,5 +1,3 @@
 FROM docker:19.03-rc
 
-RUN apk add --no-cache \
-		git \
-		openssh-client
+RUN apk add --no-cache git

--- a/19.03/Dockerfile
+++ b/19.03/Dockerfile
@@ -1,7 +1,9 @@
 FROM alpine:3.10
 
 RUN apk add --no-cache \
-		ca-certificates
+		ca-certificates \
+# DOCKER_HOST=ssh://... -- https://github.com/docker/cli/pull/1014
+		openssh-client
 
 # set up nsswitch.conf for Go's "netgo" implementation (which Docker explicitly uses)
 # - https://github.com/docker/docker-ce/blob/v17.09.0-ce/components/engine/hack/make.sh#L149

--- a/19.03/git/Dockerfile
+++ b/19.03/git/Dockerfile
@@ -1,5 +1,3 @@
 FROM docker:19.03
 
-RUN apk add --no-cache \
-		git \
-		openssh-client
+RUN apk add --no-cache git

--- a/Dockerfile-git.template
+++ b/Dockerfile-git.template
@@ -1,5 +1,3 @@
 FROM docker:%%VERSION%%
 
-RUN apk add --no-cache \
-		git \
-		openssh-client
+RUN apk add --no-cache git

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,7 +1,9 @@
 FROM alpine:%%TAG%%
 
 RUN apk add --no-cache \
-		ca-certificates
+		ca-certificates \
+# DOCKER_HOST=ssh://... -- https://github.com/docker/cli/pull/1014
+		openssh-client
 
 # set up nsswitch.conf for Go's "netgo" implementation (which Docker explicitly uses)
 # - https://github.com/docker/docker-ce/blob/v17.09.0-ce/components/engine/hack/make.sh#L149


### PR DESCRIPTION
This adds ~6MB (which is nothing compared to the Docker artifacts), and since 19.03.x gives us support for `DOCKER_HOST=ssh://...` (https://github.com/docker/cli/pull/1014)

Closes #206