### PR TITLE
Update rootlesskit to 0.9.1

### DIFF
--- a/19.03-rc/dind-rootless/Dockerfile
+++ b/19.03-rc/dind-rootless/Dockerfile
@@ -47,7 +47,7 @@ RUN set -eux; \
 	vpnkit --version
 
 # https://github.com/rootless-containers/rootlesskit/releases
-ENV ROOTLESSKIT_VERSION 0.7.1
+ENV ROOTLESSKIT_VERSION 0.9.1
 
 RUN set -eux; \
 	apk add --no-cache --virtual .rootlesskit-build-deps \

--- a/19.03-rc/dind/dockerd-entrypoint.sh
+++ b/19.03-rc/dind/dockerd-entrypoint.sh
@@ -170,7 +170,8 @@ if [ "$1" = 'dockerd' ]; then
 			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
 			--disable-host-loopback \
 			--port-driver=builtin \
-			--copy-up=/etc --copy-up=/run \
+			--copy-up=/etc \
+			--copy-up=/run \
 			${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
 			"$@" --userland-proxy-path=rootlesskit-docker-proxy
 	elif [ -x '/usr/local/bin/dind' ]; then

--- a/19.03/dind-rootless/Dockerfile
+++ b/19.03/dind-rootless/Dockerfile
@@ -47,7 +47,7 @@ RUN set -eux; \
 	vpnkit --version
 
 # https://github.com/rootless-containers/rootlesskit/releases
-ENV ROOTLESSKIT_VERSION 0.7.1
+ENV ROOTLESSKIT_VERSION 0.9.1
 
 RUN set -eux; \
 	apk add --no-cache --virtual .rootlesskit-build-deps \

--- a/19.03/dind/dockerd-entrypoint.sh
+++ b/19.03/dind/dockerd-entrypoint.sh
@@ -170,7 +170,8 @@ if [ "$1" = 'dockerd' ]; then
 			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
 			--disable-host-loopback \
 			--port-driver=builtin \
-			--copy-up=/etc --copy-up=/run \
+			--copy-up=/etc \
+			--copy-up=/run \
 			${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
 			"$@" --userland-proxy-path=rootlesskit-docker-proxy
 	elif [ -x '/usr/local/bin/dind' ]; then

--- a/Dockerfile-dind-rootless.template
+++ b/Dockerfile-dind-rootless.template
@@ -36,7 +36,7 @@ RUN set -eux; \
 	vpnkit --version
 
 # https://github.com/rootless-containers/rootlesskit/releases
-ENV ROOTLESSKIT_VERSION 0.7.1
+ENV ROOTLESSKIT_VERSION 0.9.1
 
 RUN set -eux; \
 	apk add --no-cache --virtual .rootlesskit-build-deps \

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -170,7 +170,8 @@ if [ "$1" = 'dockerd' ]; then
 			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
 			--disable-host-loopback \
 			--port-driver=builtin \
-			--copy-up=/etc --copy-up=/run \
+			--copy-up=/etc \
+			--copy-up=/run \
 			${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \
 			"$@" --userland-proxy-path=rootlesskit-docker-proxy
 	elif [ -x '/usr/local/bin/dind' ]; then


### PR DESCRIPTION
Also, update entrypoint for a few adjustments made upstream:

- https://github.com/moby/moby/pull/40635: launch rootlesskit with --propagation=rslave
- https://github.com/moby/moby/pull/39840: harden slirp4netns with mount namespace and seccomp

I was going to include https://github.com/moby/moby/pull/40406 as well, but it doesn't appear that https://github.com/moby/moby/commit/3518383ed990202d93e5458782d2c975c48ececd is in the released versions of Docker yet (and the additional argument should be reasonably harmless).