### PR TITLE
Explicitly set --oom-score-adjust to -500

### DIFF
--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -118,6 +118,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 		set -- dockerd \
 			--host="$dockerSocket" \
 			--host=tcp://0.0.0.0:2376 \
+			--oom-score-adjust=-500 \
 			--tlsverify \
 			--tlscacert "$DOCKER_TLS_CERTDIR/server/ca.pem" \
 			--tlscert "$DOCKER_TLS_CERTDIR/server/cert.pem" \
@@ -129,6 +130,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 		set -- dockerd \
 			--host="$dockerSocket" \
 			--host=tcp://0.0.0.0:2375 \
+			--oom-score-adjust=-500 \
 			"$@"
 		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"
 	fi


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/41528

Currently, dockerd sets a "-500" oom-score-adjust for itself by default.

We're removing this default, and instead:

- for dockerd running as systemd unit, set the oom-score through systemd
- when manually running dockerd, require users to explicitly set a score

This patch is in preparation of those changes.

