### PR TITLE
rootless: add fuse-overlayfs

### DIFF
--- a/20.10/dind-rootless/Dockerfile
+++ b/20.10/dind-rootless/Dockerfile
@@ -8,7 +8,7 @@ FROM docker:20.10-dind
 
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1
-RUN apk add --no-cache iproute2
+RUN apk add --no-cache iproute2 fuse-overlayfs
 
 # "/run/user/UID" will be used by default as the value of XDG_RUNTIME_DIR
 RUN mkdir /run/user && chmod 1777 /run/user

--- a/22.06-rc/dind-rootless/Dockerfile
+++ b/22.06-rc/dind-rootless/Dockerfile
@@ -8,7 +8,7 @@ FROM docker:22.06-rc-dind
 
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1
-RUN apk add --no-cache iproute2
+RUN apk add --no-cache iproute2 fuse-overlayfs
 
 # "/run/user/UID" will be used by default as the value of XDG_RUNTIME_DIR
 RUN mkdir /run/user && chmod 1777 /run/user

--- a/Dockerfile-dind-rootless.template
+++ b/Dockerfile-dind-rootless.template
@@ -2,7 +2,7 @@ FROM docker:{{ env.version }}-dind
 
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1
-RUN apk add --no-cache iproute2
+RUN apk add --no-cache iproute2 fuse-overlayfs
 
 # "/run/user/UID" will be used by default as the value of XDG_RUNTIME_DIR
 RUN mkdir /run/user && chmod 1777 /run/user


### PR DESCRIPTION
The kernel-mode overlayfs doesn't work with rootless, though Ubuntu and Debian has patched their kernels to enable overlayfs for rootless.

OTOH fuse-overlayfs works with rootless on any distro with kernel >= 4.18.

fuse-overlayfs is supported since Docker 20.10.

https://github.com/moby/moby/issues/40218
