### PR TITLE
rootless: set ENV DOCKER_HOST=unix:///run/user/1000/docker.sock

### DIFF
--- a/19.03-rc/dind-rootless/Dockerfile
+++ b/19.03-rc/dind-rootless/Dockerfile
@@ -6,6 +6,8 @@
 
 FROM docker:19.03-rc-dind
 
+ARG ROOTLESS_UID=1000
+
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1
 RUN apk add --no-cache iproute2
@@ -15,7 +17,7 @@ RUN mkdir /run/user && chmod 1777 /run/user
 
 # create a default user preconfigured for running rootless dockerd
 RUN set -eux; \
-	adduser -h /home/rootless -g 'Rootless' -D -u 1000 rootless; \
+	adduser -h /home/rootless -g 'Rootless' -D -u ${ROOTLESS_UID} rootless; \
 	echo 'rootless:100000:65536' >> /etc/subuid; \
 	echo 'rootless:100000:65536' >> /etc/subgid
 
@@ -68,3 +70,4 @@ RUN set -eux; \
 	chown -R rootless:rootless /home/rootless/.local/share/docker
 VOLUME /home/rootless/.local/share/docker
 USER rootless
+ENV DOCKER_HOST unix:///run/user/${ROOTLESS_UID}/docker.sock

--- a/19.03/dind-rootless/Dockerfile
+++ b/19.03/dind-rootless/Dockerfile
@@ -6,6 +6,8 @@
 
 FROM docker:19.03-dind
 
+ARG ROOTLESS_UID=1000
+
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1
 RUN apk add --no-cache iproute2
@@ -15,7 +17,7 @@ RUN mkdir /run/user && chmod 1777 /run/user
 
 # create a default user preconfigured for running rootless dockerd
 RUN set -eux; \
-	adduser -h /home/rootless -g 'Rootless' -D -u 1000 rootless; \
+	adduser -h /home/rootless -g 'Rootless' -D -u ${ROOTLESS_UID} rootless; \
 	echo 'rootless:100000:65536' >> /etc/subuid; \
 	echo 'rootless:100000:65536' >> /etc/subgid
 
@@ -68,3 +70,4 @@ RUN set -eux; \
 	chown -R rootless:rootless /home/rootless/.local/share/docker
 VOLUME /home/rootless/.local/share/docker
 USER rootless
+ENV DOCKER_HOST unix:///run/user/${ROOTLESS_UID}/docker.sock

--- a/20.10-rc/dind-rootless/Dockerfile
+++ b/20.10-rc/dind-rootless/Dockerfile
@@ -6,6 +6,8 @@
 
 FROM docker:20.10-rc-dind
 
+ARG ROOTLESS_UID=1000
+
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1
 RUN apk add --no-cache iproute2
@@ -15,7 +17,7 @@ RUN mkdir /run/user && chmod 1777 /run/user
 
 # create a default user preconfigured for running rootless dockerd
 RUN set -eux; \
-	adduser -h /home/rootless -g 'Rootless' -D -u 1000 rootless; \
+	adduser -h /home/rootless -g 'Rootless' -D -u ${ROOTLESS_UID} rootless; \
 	echo 'rootless:100000:65536' >> /etc/subuid; \
 	echo 'rootless:100000:65536' >> /etc/subgid
 
@@ -68,3 +70,4 @@ RUN set -eux; \
 	chown -R rootless:rootless /home/rootless/.local/share/docker
 VOLUME /home/rootless/.local/share/docker
 USER rootless
+ENV DOCKER_HOST unix:///run/user/${ROOTLESS_UID}/docker.sock

--- a/Dockerfile-dind-rootless.template
+++ b/Dockerfile-dind-rootless.template
@@ -1,5 +1,7 @@
 FROM docker:{{ env.version }}-dind
 
+ARG ROOTLESS_UID=1000
+
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1
 RUN apk add --no-cache iproute2
@@ -9,7 +11,7 @@ RUN mkdir /run/user && chmod 1777 /run/user
 
 # create a default user preconfigured for running rootless dockerd
 RUN set -eux; \
-	adduser -h /home/rootless -g 'Rootless' -D -u 1000 rootless; \
+	adduser -h /home/rootless -g 'Rootless' -D -u ${ROOTLESS_UID} rootless; \
 	echo 'rootless:100000:65536' >> /etc/subuid; \
 	echo 'rootless:100000:65536' >> /etc/subgid
 
@@ -83,3 +85,4 @@ RUN set -eux; \
 	chown -R rootless:rootless /home/rootless/.local/share/docker
 VOLUME /home/rootless/.local/share/docker
 USER rootless
+ENV DOCKER_HOST unix:///run/user/${ROOTLESS_UID}/docker.sock


### PR DESCRIPTION
This allows `docker exec $ID docker run ...` without setting `-H` manually.

