### PR TITLE
Remove explicit rootlesskit version

### DIFF
--- a/19.03-rc/dind-rootless/Dockerfile
+++ b/19.03-rc/dind-rootless/Dockerfile
@@ -35,32 +35,14 @@ RUN set -eux; \
 		--file rootless.tgz \
 		--strip-components 1 \
 		--directory /usr/local/bin/ \
+		'docker-rootless-extras/rootlesskit' \
+		'docker-rootless-extras/rootlesskit-docker-proxy' \
 		'docker-rootless-extras/vpnkit' \
 	; \
 	rm rootless.tgz; \
 	\
-# we download/build rootlesskit separately to get a newer release
-#	rootlesskit --version; \
+	rootlesskit --version; \
 	vpnkit --version
-
-# https://github.com/rootless-containers/rootlesskit/releases
-ENV ROOTLESSKIT_VERSION 0.11.0
-
-RUN set -eux; \
-	apk add --no-cache --virtual .rootlesskit-build-deps \
-		go \
-		libc-dev \
-	; \
-	wget -O rootlesskit.tgz "https://github.com/rootless-containers/rootlesskit/archive/v${ROOTLESSKIT_VERSION}.tar.gz"; \
-	export GOPATH='/go'; mkdir "$GOPATH"; \
-	mkdir -p "$GOPATH/src/github.com/rootless-containers/rootlesskit"; \
-	tar --extract --file rootlesskit.tgz --directory "$GOPATH/src/github.com/rootless-containers/rootlesskit" --strip-components 1; \
-	rm rootlesskit.tgz; \
-	go build -o /usr/local/bin/rootlesskit github.com/rootless-containers/rootlesskit/cmd/rootlesskit; \
-	go build -o /usr/local/bin/rootlesskit-docker-proxy github.com/rootless-containers/rootlesskit/cmd/rootlesskit-docker-proxy; \
-	rm -rf "$GOPATH"; \
-	apk del --no-network .rootlesskit-build-deps; \
-	rootlesskit --version
 
 # pre-create "/var/lib/docker" for our rootless user
 RUN set -eux; \

--- a/19.03/dind-rootless/Dockerfile
+++ b/19.03/dind-rootless/Dockerfile
@@ -35,32 +35,14 @@ RUN set -eux; \
 		--file rootless.tgz \
 		--strip-components 1 \
 		--directory /usr/local/bin/ \
+		'docker-rootless-extras/rootlesskit' \
+		'docker-rootless-extras/rootlesskit-docker-proxy' \
 		'docker-rootless-extras/vpnkit' \
 	; \
 	rm rootless.tgz; \
 	\
-# we download/build rootlesskit separately to get a newer release
-#	rootlesskit --version; \
+	rootlesskit --version; \
 	vpnkit --version
-
-# https://github.com/rootless-containers/rootlesskit/releases
-ENV ROOTLESSKIT_VERSION 0.11.0
-
-RUN set -eux; \
-	apk add --no-cache --virtual .rootlesskit-build-deps \
-		go \
-		libc-dev \
-	; \
-	wget -O rootlesskit.tgz "https://github.com/rootless-containers/rootlesskit/archive/v${ROOTLESSKIT_VERSION}.tar.gz"; \
-	export GOPATH='/go'; mkdir "$GOPATH"; \
-	mkdir -p "$GOPATH/src/github.com/rootless-containers/rootlesskit"; \
-	tar --extract --file rootlesskit.tgz --directory "$GOPATH/src/github.com/rootless-containers/rootlesskit" --strip-components 1; \
-	rm rootlesskit.tgz; \
-	go build -o /usr/local/bin/rootlesskit github.com/rootless-containers/rootlesskit/cmd/rootlesskit; \
-	go build -o /usr/local/bin/rootlesskit-docker-proxy github.com/rootless-containers/rootlesskit/cmd/rootlesskit-docker-proxy; \
-	rm -rf "$GOPATH"; \
-	apk del --no-network .rootlesskit-build-deps; \
-	rootlesskit --version
 
 # pre-create "/var/lib/docker" for our rootless user
 RUN set -eux; \

--- a/20.10-rc/dind-rootless/Dockerfile
+++ b/20.10-rc/dind-rootless/Dockerfile
@@ -35,32 +35,14 @@ RUN set -eux; \
 		--file rootless.tgz \
 		--strip-components 1 \
 		--directory /usr/local/bin/ \
+		'docker-rootless-extras/rootlesskit' \
+		'docker-rootless-extras/rootlesskit-docker-proxy' \
 		'docker-rootless-extras/vpnkit' \
 	; \
 	rm rootless.tgz; \
 	\
-# we download/build rootlesskit separately to get a newer release
-#	rootlesskit --version; \
+	rootlesskit --version; \
 	vpnkit --version
-
-# https://github.com/rootless-containers/rootlesskit/releases
-ENV ROOTLESSKIT_VERSION 0.11.0
-
-RUN set -eux; \
-	apk add --no-cache --virtual .rootlesskit-build-deps \
-		go \
-		libc-dev \
-	; \
-	wget -O rootlesskit.tgz "https://github.com/rootless-containers/rootlesskit/archive/v${ROOTLESSKIT_VERSION}.tar.gz"; \
-	export GOPATH='/go'; mkdir "$GOPATH"; \
-	mkdir -p "$GOPATH/src/github.com/rootless-containers/rootlesskit"; \
-	tar --extract --file rootlesskit.tgz --directory "$GOPATH/src/github.com/rootless-containers/rootlesskit" --strip-components 1; \
-	rm rootlesskit.tgz; \
-	go build -o /usr/local/bin/rootlesskit github.com/rootless-containers/rootlesskit/cmd/rootlesskit; \
-	go build -o /usr/local/bin/rootlesskit-docker-proxy github.com/rootless-containers/rootlesskit/cmd/rootlesskit-docker-proxy; \
-	rm -rf "$GOPATH"; \
-	apk del --no-network .rootlesskit-build-deps; \
-	rootlesskit --version
 
 # pre-create "/var/lib/docker" for our rootless user
 RUN set -eux; \

--- a/Dockerfile-dind-rootless.template
+++ b/Dockerfile-dind-rootless.template
@@ -50,32 +50,14 @@ RUN set -eux; \
 		--file rootless.tgz \
 		--strip-components 1 \
 		--directory /usr/local/bin/ \
+		'docker-rootless-extras/rootlesskit' \
+		'docker-rootless-extras/rootlesskit-docker-proxy' \
 		'docker-rootless-extras/vpnkit' \
 	; \
 	rm rootless.tgz; \
 	\
-# we download/build rootlesskit separately to get a newer release
-#	rootlesskit --version; \
+	rootlesskit --version; \
 	vpnkit --version
-
-# https://github.com/rootless-containers/rootlesskit/releases
-ENV ROOTLESSKIT_VERSION 0.11.0
-
-RUN set -eux; \
-	apk add --no-cache --virtual .rootlesskit-build-deps \
-		go \
-		libc-dev \
-	; \
-	wget -O rootlesskit.tgz "https://github.com/rootless-containers/rootlesskit/archive/v${ROOTLESSKIT_VERSION}.tar.gz"; \
-	export GOPATH='/go'; mkdir "$GOPATH"; \
-	mkdir -p "$GOPATH/src/github.com/rootless-containers/rootlesskit"; \
-	tar --extract --file rootlesskit.tgz --directory "$GOPATH/src/github.com/rootless-containers/rootlesskit" --strip-components 1; \
-	rm rootlesskit.tgz; \
-	go build -o /usr/local/bin/rootlesskit github.com/rootless-containers/rootlesskit/cmd/rootlesskit; \
-	go build -o /usr/local/bin/rootlesskit-docker-proxy github.com/rootless-containers/rootlesskit/cmd/rootlesskit-docker-proxy; \
-	rm -rf "$GOPATH"; \
-	apk del --no-network .rootlesskit-build-deps; \
-	rootlesskit --version
 
 # pre-create "/var/lib/docker" for our rootless user
 RUN set -eux; \


### PR DESCRIPTION
We were explicit about this previously because the version included with Docker wasn't new enough, and that's no longer the case.

Closes #269 (thanks for the prod, @vicamo!)