### PR TITLE
rootless: replace VPNKit with slirp4netns + support ARM

### DIFF
--- a/19.03-rc/dind-rootless/Dockerfile
+++ b/19.03-rc/dind-rootless/Dockerfile
@@ -26,6 +26,15 @@ RUN set -eux; \
 		'x86_64') \
 			url='https://download.docker.com/linux/static/test/x86_64/docker-rootless-extras-19.03.13-beta2.tgz'; \
 			;; \
+		'armhf') \
+			url='https://download.docker.com/linux/static/test/armel/docker-rootless-extras-19.03.13-beta2.tgz'; \
+			;; \
+		'armv7') \
+			url='https://download.docker.com/linux/static/test/armhf/docker-rootless-extras-19.03.13-beta2.tgz'; \
+			;; \
+		'aarch64') \
+			url='https://download.docker.com/linux/static/test/aarch64/docker-rootless-extras-19.03.13-beta2.tgz'; \
+			;; \
 		*) echo >&2 "error: unsupported architecture ($apkArch)"; exit 1 ;; \
 	esac; \
 	\
@@ -37,12 +46,24 @@ RUN set -eux; \
 		--directory /usr/local/bin/ \
 		'docker-rootless-extras/rootlesskit' \
 		'docker-rootless-extras/rootlesskit-docker-proxy' \
-		'docker-rootless-extras/vpnkit' \
 	; \
 	rm rootless.tgz; \
 	\
-	rootlesskit --version; \
-	vpnkit --version
+	rootlesskit --version
+
+# We do not use vpnkit binary included in x86_64 version of docker-rootless-extras,
+# because it is not available for other architectures and yet slower than slirp4netns.
+
+ENV SLIRP4NETNS_VERSION 1.1.8
+ENV SLIRP4NETNS_SHA256SUMS_SHA256 366f40a49c0cf25b7e2ee22e9fae6df575127aef75f968454f5705a1ff0784ff
+RUN set -eux; \
+  wget https://github.com/rootless-containers/slirp4netns/releases/download/v${SLIRP4NETNS_VERSION}/slirp4netns-$(uname -m); \
+  wget https://github.com/rootless-containers/slirp4netns/releases/download/v${SLIRP4NETNS_VERSION}/SHA256SUMS; \
+  echo "$SLIRP4NETNS_SHA256SUMS_SHA256  SHA256SUMS" | sha256sum -c -; \
+  grep "slirp4netns-$(uname -m)" SHA256SUMS | sha256sum -c -; \
+  mv slirp4netns-$(uname -m) /usr/local/bin/slirp4netns; \
+  rm -f SHA256SUMS; \
+  chmod +x /usr/local/bin/slirp4netns
 
 # pre-create "/var/lib/docker" for our rootless user
 RUN set -eux; \

--- a/19.03-rc/dind/dockerd-entrypoint.sh
+++ b/19.03-rc/dind/dockerd-entrypoint.sh
@@ -166,10 +166,12 @@ if [ "$1" = 'dockerd' ]; then
 		fi
 		# TODO overlay support detection?
 		exec rootlesskit \
-			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
-			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-slirp4netns}" \
+			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-65520}" \
+			--slirp4netns-sandbox="${DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SANDBOX:-auto}" \
+			--slirp4netns-seccomp="${DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SECCOMP:-auto}" \
 			--disable-host-loopback \
-			--port-driver=builtin \
+			--port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
 			--copy-up=/etc \
 			--copy-up=/run \
 			${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \

--- a/19.03/dind-rootless/Dockerfile
+++ b/19.03/dind-rootless/Dockerfile
@@ -26,6 +26,15 @@ RUN set -eux; \
 		'x86_64') \
 			url='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-19.03.15.tgz'; \
 			;; \
+		'armhf') \
+			url='https://download.docker.com/linux/static/stable/armel/docker-rootless-extras-19.03.15.tgz'; \
+			;; \
+		'armv7') \
+			url='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-19.03.15.tgz'; \
+			;; \
+		'aarch64') \
+			url='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-19.03.15.tgz'; \
+			;; \
 		*) echo >&2 "error: unsupported architecture ($apkArch)"; exit 1 ;; \
 	esac; \
 	\
@@ -37,12 +46,24 @@ RUN set -eux; \
 		--directory /usr/local/bin/ \
 		'docker-rootless-extras/rootlesskit' \
 		'docker-rootless-extras/rootlesskit-docker-proxy' \
-		'docker-rootless-extras/vpnkit' \
 	; \
 	rm rootless.tgz; \
 	\
-	rootlesskit --version; \
-	vpnkit --version
+	rootlesskit --version
+
+# We do not use vpnkit binary included in x86_64 version of docker-rootless-extras,
+# because it is not available for other architectures and yet slower than slirp4netns.
+
+ENV SLIRP4NETNS_VERSION 1.1.8
+ENV SLIRP4NETNS_SHA256SUMS_SHA256 366f40a49c0cf25b7e2ee22e9fae6df575127aef75f968454f5705a1ff0784ff
+RUN set -eux; \
+  wget https://github.com/rootless-containers/slirp4netns/releases/download/v${SLIRP4NETNS_VERSION}/slirp4netns-$(uname -m); \
+  wget https://github.com/rootless-containers/slirp4netns/releases/download/v${SLIRP4NETNS_VERSION}/SHA256SUMS; \
+  echo "$SLIRP4NETNS_SHA256SUMS_SHA256  SHA256SUMS" | sha256sum -c -; \
+  grep "slirp4netns-$(uname -m)" SHA256SUMS | sha256sum -c -; \
+  mv slirp4netns-$(uname -m) /usr/local/bin/slirp4netns; \
+  rm -f SHA256SUMS; \
+  chmod +x /usr/local/bin/slirp4netns
 
 # pre-create "/var/lib/docker" for our rootless user
 RUN set -eux; \

--- a/19.03/dind/dockerd-entrypoint.sh
+++ b/19.03/dind/dockerd-entrypoint.sh
@@ -166,10 +166,12 @@ if [ "$1" = 'dockerd' ]; then
 		fi
 		# TODO overlay support detection?
 		exec rootlesskit \
-			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
-			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-slirp4netns}" \
+			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-65520}" \
+			--slirp4netns-sandbox="${DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SANDBOX:-auto}" \
+			--slirp4netns-seccomp="${DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SECCOMP:-auto}" \
 			--disable-host-loopback \
-			--port-driver=builtin \
+			--port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
 			--copy-up=/etc \
 			--copy-up=/run \
 			${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \

--- a/20.10-rc/dind-rootless/Dockerfile
+++ b/20.10-rc/dind-rootless/Dockerfile
@@ -26,6 +26,15 @@ RUN set -eux; \
 		'x86_64') \
 			url='https://download.docker.com/linux/static/test/x86_64/docker-rootless-extras-20.10.0-rc2.tgz'; \
 			;; \
+		'armhf') \
+			url='https://download.docker.com/linux/static/test/armel/docker-rootless-extras-20.10.0-rc2.tgz'; \
+			;; \
+		'armv7') \
+			url='https://download.docker.com/linux/static/test/armhf/docker-rootless-extras-20.10.0-rc2.tgz'; \
+			;; \
+		'aarch64') \
+			url='https://download.docker.com/linux/static/test/aarch64/docker-rootless-extras-20.10.0-rc2.tgz'; \
+			;; \
 		*) echo >&2 "error: unsupported architecture ($apkArch)"; exit 1 ;; \
 	esac; \
 	\
@@ -37,12 +46,24 @@ RUN set -eux; \
 		--directory /usr/local/bin/ \
 		'docker-rootless-extras/rootlesskit' \
 		'docker-rootless-extras/rootlesskit-docker-proxy' \
-		'docker-rootless-extras/vpnkit' \
 	; \
 	rm rootless.tgz; \
 	\
-	rootlesskit --version; \
-	vpnkit --version
+	rootlesskit --version
+
+# We do not use vpnkit binary included in x86_64 version of docker-rootless-extras,
+# because it is not available for other architectures and yet slower than slirp4netns.
+
+ENV SLIRP4NETNS_VERSION 1.1.8
+ENV SLIRP4NETNS_SHA256SUMS_SHA256 366f40a49c0cf25b7e2ee22e9fae6df575127aef75f968454f5705a1ff0784ff
+RUN set -eux; \
+  wget https://github.com/rootless-containers/slirp4netns/releases/download/v${SLIRP4NETNS_VERSION}/slirp4netns-$(uname -m); \
+  wget https://github.com/rootless-containers/slirp4netns/releases/download/v${SLIRP4NETNS_VERSION}/SHA256SUMS; \
+  echo "$SLIRP4NETNS_SHA256SUMS_SHA256  SHA256SUMS" | sha256sum -c -; \
+  grep "slirp4netns-$(uname -m)" SHA256SUMS | sha256sum -c -; \
+  mv slirp4netns-$(uname -m) /usr/local/bin/slirp4netns; \
+  rm -f SHA256SUMS; \
+  chmod +x /usr/local/bin/slirp4netns
 
 # pre-create "/var/lib/docker" for our rootless user
 RUN set -eux; \

--- a/20.10-rc/dind/dockerd-entrypoint.sh
+++ b/20.10-rc/dind/dockerd-entrypoint.sh
@@ -166,10 +166,12 @@ if [ "$1" = 'dockerd' ]; then
 		fi
 		# TODO overlay support detection?
 		exec rootlesskit \
-			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
-			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-slirp4netns}" \
+			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-65520}" \
+			--slirp4netns-sandbox="${DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SANDBOX:-auto}" \
+			--slirp4netns-seccomp="${DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SECCOMP:-auto}" \
 			--disable-host-loopback \
-			--port-driver=builtin \
+			--port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
 			--copy-up=/etc \
 			--copy-up=/run \
 			${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \

--- a/20.10/dind-rootless/Dockerfile
+++ b/20.10/dind-rootless/Dockerfile
@@ -26,6 +26,15 @@ RUN set -eux; \
 		'x86_64') \
 			url='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.3.tgz'; \
 			;; \
+		'armhf') \
+			url='https://download.docker.com/linux/static/stable/armel/docker-rootless-extras-20.10.3.tgz'; \
+			;; \
+		'armv7') \
+			url='https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.3.tgz'; \
+			;; \
+		'aarch64') \
+			url='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.3.tgz'; \
+			;; \
 		*) echo >&2 "error: unsupported architecture ($apkArch)"; exit 1 ;; \
 	esac; \
 	\
@@ -37,12 +46,24 @@ RUN set -eux; \
 		--directory /usr/local/bin/ \
 		'docker-rootless-extras/rootlesskit' \
 		'docker-rootless-extras/rootlesskit-docker-proxy' \
-		'docker-rootless-extras/vpnkit' \
 	; \
 	rm rootless.tgz; \
 	\
-	rootlesskit --version; \
-	vpnkit --version
+	rootlesskit --version
+
+# We do not use vpnkit binary included in x86_64 version of docker-rootless-extras,
+# because it is not available for other architectures and yet slower than slirp4netns.
+
+ENV SLIRP4NETNS_VERSION 1.1.8
+ENV SLIRP4NETNS_SHA256SUMS_SHA256 366f40a49c0cf25b7e2ee22e9fae6df575127aef75f968454f5705a1ff0784ff
+RUN set -eux; \
+  wget https://github.com/rootless-containers/slirp4netns/releases/download/v${SLIRP4NETNS_VERSION}/slirp4netns-$(uname -m); \
+  wget https://github.com/rootless-containers/slirp4netns/releases/download/v${SLIRP4NETNS_VERSION}/SHA256SUMS; \
+  echo "$SLIRP4NETNS_SHA256SUMS_SHA256  SHA256SUMS" | sha256sum -c -; \
+  grep "slirp4netns-$(uname -m)" SHA256SUMS | sha256sum -c -; \
+  mv slirp4netns-$(uname -m) /usr/local/bin/slirp4netns; \
+  rm -f SHA256SUMS; \
+  chmod +x /usr/local/bin/slirp4netns
 
 # pre-create "/var/lib/docker" for our rootless user
 RUN set -eux; \

--- a/20.10/dind/dockerd-entrypoint.sh
+++ b/20.10/dind/dockerd-entrypoint.sh
@@ -166,10 +166,12 @@ if [ "$1" = 'dockerd' ]; then
 		fi
 		# TODO overlay support detection?
 		exec rootlesskit \
-			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
-			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-slirp4netns}" \
+			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-65520}" \
+			--slirp4netns-sandbox="${DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SANDBOX:-auto}" \
+			--slirp4netns-seccomp="${DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SECCOMP:-auto}" \
 			--disable-host-loopback \
-			--port-driver=builtin \
+			--port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
 			--copy-up=/etc \
 			--copy-up=/run \
 			${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \

--- a/Dockerfile-dind-rootless.template
+++ b/Dockerfile-dind-rootless.template
@@ -52,12 +52,24 @@ RUN set -eux; \
 		--directory /usr/local/bin/ \
 		'docker-rootless-extras/rootlesskit' \
 		'docker-rootless-extras/rootlesskit-docker-proxy' \
-		'docker-rootless-extras/vpnkit' \
 	; \
 	rm rootless.tgz; \
 	\
-	rootlesskit --version; \
-	vpnkit --version
+	rootlesskit --version
+
+# We do not use vpnkit binary included in x86_64 version of docker-rootless-extras,
+# because it is not available for other architectures and yet slower than slirp4netns.
+
+ENV SLIRP4NETNS_VERSION 1.1.8
+ENV SLIRP4NETNS_SHA256SUMS_SHA256 366f40a49c0cf25b7e2ee22e9fae6df575127aef75f968454f5705a1ff0784ff
+RUN set -eux; \
+  wget https://github.com/rootless-containers/slirp4netns/releases/download/v${SLIRP4NETNS_VERSION}/slirp4netns-$(uname -m); \
+  wget https://github.com/rootless-containers/slirp4netns/releases/download/v${SLIRP4NETNS_VERSION}/SHA256SUMS; \
+  echo "$SLIRP4NETNS_SHA256SUMS_SHA256  SHA256SUMS" | sha256sum -c -; \
+  grep "slirp4netns-$(uname -m)" SHA256SUMS | sha256sum -c -; \
+  mv slirp4netns-$(uname -m) /usr/local/bin/slirp4netns; \
+  rm -f SHA256SUMS; \
+  chmod +x /usr/local/bin/slirp4netns
 
 # pre-create "/var/lib/docker" for our rootless user
 RUN set -eux; \

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -166,10 +166,12 @@ if [ "$1" = 'dockerd' ]; then
 		fi
 		# TODO overlay support detection?
 		exec rootlesskit \
-			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
-			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
+			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-slirp4netns}" \
+			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-65520}" \
+			--slirp4netns-sandbox="${DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SANDBOX:-auto}" \
+			--slirp4netns-seccomp="${DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SECCOMP:-auto}" \
 			--disable-host-loopback \
-			--port-driver=builtin \
+			--port-driver="${DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER:-builtin}" \
 			--copy-up=/etc \
 			--copy-up=/run \
 			${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} \

--- a/versions.json
+++ b/versions.json
@@ -7,13 +7,16 @@
         "rootlessExtrasUrl": "https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-19.03.15.tgz"
       },
       "arm32v6": {
-        "dockerUrl": "https://download.docker.com/linux/static/stable/armel/docker-19.03.15.tgz"
+        "dockerUrl": "https://download.docker.com/linux/static/stable/armel/docker-19.03.15.tgz",
+        "rootlessExtrasUrl": "https://download.docker.com/linux/static/stable/armel/docker-rootless-extras-19.03.15.tgz"
       },
       "arm32v7": {
-        "dockerUrl": "https://download.docker.com/linux/static/stable/armhf/docker-19.03.15.tgz"
+        "dockerUrl": "https://download.docker.com/linux/static/stable/armhf/docker-19.03.15.tgz",
+        "rootlessExtrasUrl": "https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-19.03.15.tgz"
       },
       "arm64v8": {
-        "dockerUrl": "https://download.docker.com/linux/static/stable/aarch64/docker-19.03.15.tgz"
+        "dockerUrl": "https://download.docker.com/linux/static/stable/aarch64/docker-19.03.15.tgz",
+        "rootlessExtrasUrl": "https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-19.03.15.tgz"
       }
     },
     "dindCommit": "ed89041433a031cafc0a0f19cfe573c31688d377",
@@ -33,13 +36,16 @@
         "rootlessExtrasUrl": "https://download.docker.com/linux/static/test/x86_64/docker-rootless-extras-19.03.13-beta2.tgz"
       },
       "arm32v6": {
-        "dockerUrl": "https://download.docker.com/linux/static/test/armel/docker-19.03.13-beta2.tgz"
+        "dockerUrl": "https://download.docker.com/linux/static/test/armel/docker-19.03.13-beta2.tgz",
+        "rootlessExtrasUrl": "https://download.docker.com/linux/static/test/armel/docker-rootless-extras-19.03.13-beta2.tgz"
       },
       "arm32v7": {
-        "dockerUrl": "https://download.docker.com/linux/static/test/armhf/docker-19.03.13-beta2.tgz"
+        "dockerUrl": "https://download.docker.com/linux/static/test/armhf/docker-19.03.13-beta2.tgz",
+        "rootlessExtrasUrl": "https://download.docker.com/linux/static/test/armhf/docker-rootless-extras-19.03.13-beta2.tgz"
       },
       "arm64v8": {
-        "dockerUrl": "https://download.docker.com/linux/static/test/aarch64/docker-19.03.13-beta2.tgz"
+        "dockerUrl": "https://download.docker.com/linux/static/test/aarch64/docker-19.03.13-beta2.tgz",
+        "rootlessExtrasUrl": "https://download.docker.com/linux/static/test/aarch64/docker-rootless-extras-19.03.13-beta2.tgz"
       }
     },
     "dindCommit": "ed89041433a031cafc0a0f19cfe573c31688d377",
@@ -59,13 +65,16 @@
         "rootlessExtrasUrl": "https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-20.10.3.tgz"
       },
       "arm32v6": {
-        "dockerUrl": "https://download.docker.com/linux/static/stable/armel/docker-20.10.3.tgz"
+        "dockerUrl": "https://download.docker.com/linux/static/stable/armel/docker-20.10.3.tgz",
+        "rootlessExtrasUrl": "https://download.docker.com/linux/static/stable/armel/docker-rootless-extras-20.10.3.tgz"
       },
       "arm32v7": {
-        "dockerUrl": "https://download.docker.com/linux/static/stable/armhf/docker-20.10.3.tgz"
+        "dockerUrl": "https://download.docker.com/linux/static/stable/armhf/docker-20.10.3.tgz",
+        "rootlessExtrasUrl": "https://download.docker.com/linux/static/stable/armhf/docker-rootless-extras-20.10.3.tgz"
       },
       "arm64v8": {
-        "dockerUrl": "https://download.docker.com/linux/static/stable/aarch64/docker-20.10.3.tgz"
+        "dockerUrl": "https://download.docker.com/linux/static/stable/aarch64/docker-20.10.3.tgz",
+        "rootlessExtrasUrl": "https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-20.10.3.tgz"
       }
     },
     "dindCommit": "ed89041433a031cafc0a0f19cfe573c31688d377",
@@ -85,13 +94,16 @@
         "rootlessExtrasUrl": "https://download.docker.com/linux/static/test/x86_64/docker-rootless-extras-20.10.0-rc2.tgz"
       },
       "arm32v6": {
-        "dockerUrl": "https://download.docker.com/linux/static/test/armel/docker-20.10.0-rc2.tgz"
+        "dockerUrl": "https://download.docker.com/linux/static/test/armel/docker-20.10.0-rc2.tgz",
+        "rootlessExtrasUrl": "https://download.docker.com/linux/static/test/armel/docker-rootless-extras-20.10.0-rc2.tgz"
       },
       "arm32v7": {
-        "dockerUrl": "https://download.docker.com/linux/static/test/armhf/docker-20.10.0-rc2.tgz"
+        "dockerUrl": "https://download.docker.com/linux/static/test/armhf/docker-20.10.0-rc2.tgz",
+        "rootlessExtrasUrl": "https://download.docker.com/linux/static/test/armhf/docker-rootless-extras-20.10.0-rc2.tgz"
       },
       "arm64v8": {
-        "dockerUrl": "https://download.docker.com/linux/static/test/aarch64/docker-20.10.0-rc2.tgz"
+        "dockerUrl": "https://download.docker.com/linux/static/test/aarch64/docker-20.10.0-rc2.tgz",
+        "rootlessExtrasUrl": "https://download.docker.com/linux/static/test/aarch64/docker-rootless-extras-20.10.0-rc2.tgz"
       }
     },
     "dindCommit": "ed89041433a031cafc0a0f19cfe573c31688d377",

--- a/versions.sh
+++ b/versions.sh
@@ -115,8 +115,7 @@ for version in "${versions[@]}"; do
 
 		rootlessExtrasUrl="https://download.docker.com/linux/static/$channel/$arch/docker-rootless-extras-$fullVersion.tgz"
 		# https://github.com/docker/docker-ce/blob/8fb3bb7b2210789a4471c017561c1b0de0b4f145/components/engine/hack/make/binary-daemon#L24
-		# "vpnkit is amd64-only" ... for now??
-		if [ "$bashbrewArch" = 'amd64' ] && wget --quiet --spider "$rootlessExtrasUrl" &> /dev/null; then
+		if wget --quiet --spider "$rootlessExtrasUrl" &> /dev/null; then
 			export rootlessExtrasUrl
 			doc="$(
 				jq <<<"$doc" -c \


### PR DESCRIPTION
The rootless image was not built for ARM because VPNKit binary is not available for ARM.
This commit supports ARM by replacing VPNKit with slirp4netns.

slirp4netns also has several advantages over VPNkit (but not included in docker-rootless-extras archive because slirp4netns is GPL2):
- Faster than VPNKit, e.g. 0.60 Gbps vs 7.55 Gbps: https://github.com/rootless-containers/rootlesskit/tree/v0.11.1#network-drivers
- Can preserve src IP of incomming connections into `docker run -p` ports, by setting `$DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER` to "slirp4netns".
  (Otherwise incoming connections look like as if they were from localhost)
- Supports sandboxing slirp4netns itself using mount namespace and seccomp
