### PR TITLE
Add ip6tables in 20.10+

### DIFF
--- a/20.10-rc/dind/Dockerfile
+++ b/20.10-rc/dind/Dockerfile
@@ -12,6 +12,7 @@ RUN set -eux; \
 		btrfs-progs \
 		e2fsprogs \
 		e2fsprogs-extra \
+		ip6tables \
 		iptables \
 		openssl \
 		shadow-uidmap \

--- a/20.10/dind/Dockerfile
+++ b/20.10/dind/Dockerfile
@@ -12,6 +12,7 @@ RUN set -eux; \
 		btrfs-progs \
 		e2fsprogs \
 		e2fsprogs-extra \
+		ip6tables \
 		iptables \
 		openssl \
 		shadow-uidmap \

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -6,6 +6,9 @@ RUN set -eux; \
 		btrfs-progs \
 		e2fsprogs \
 		e2fsprogs-extra \
+{{ if ["19.03", "19.03-rc"] | index(env.version) | not then ( -}}
+		ip6tables \
+{{ ) else "" end -}}
 		iptables \
 		openssl \
 		shadow-uidmap \


### PR DESCRIPTION
Docker 20.10+ now supports ip6tables!