### PR TITLE
update to alpine 3.13

### DIFF
--- a/19.03-rc/Dockerfile
+++ b/19.03-rc/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 RUN apk add --no-cache \
 		ca-certificates \

--- a/19.03/Dockerfile
+++ b/19.03/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 RUN apk add --no-cache \
 		ca-certificates \

--- a/20.10-rc/Dockerfile
+++ b/20.10-rc/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 RUN apk add --no-cache \
 		ca-certificates \

--- a/20.10/Dockerfile
+++ b/20.10/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 RUN apk add --no-cache \
 		ca-certificates \

--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
   "19.03": {
-    "alpine": "3.12",
+    "alpine": "3.13",
     "arches": {
       "amd64": {
         "dockerUrl": "https://download.docker.com/linux/static/stable/x86_64/docker-19.03.14.tgz",
@@ -26,7 +26,7 @@
     "version": "19.03.14"
   },
   "19.03-rc": {
-    "alpine": "3.12",
+    "alpine": "3.13",
     "arches": {
       "amd64": {
         "dockerUrl": "https://download.docker.com/linux/static/test/x86_64/docker-19.03.13-beta2.tgz",
@@ -52,7 +52,7 @@
     "version": "19.03.13-beta2"
   },
   "20.10": {
-    "alpine": "3.12",
+    "alpine": "3.13",
     "arches": {
       "amd64": {
         "dockerUrl": "https://download.docker.com/linux/static/stable/x86_64/docker-20.10.2.tgz",
@@ -78,7 +78,7 @@
     "version": "20.10.2"
   },
   "20.10-rc": {
-    "alpine": "3.12",
+    "alpine": "3.13",
     "arches": {
       "amd64": {
         "dockerUrl": "https://download.docker.com/linux/static/test/x86_64/docker-20.10.0-rc2.tgz",

--- a/versions.sh
+++ b/versions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-defaultAlpineVersion='3.12'
+defaultAlpineVersion='3.13'
 declare -A alpineVersion=(
 	#[17.09]='3.6'
 )


### PR DESCRIPTION
This is especially useful for downstream consumers of the DIND images as 3.12 had some quite old packages

Signed-off-by: Martin Rauscher <martin@balena.io>