### PR TITLE
[RFC] dind: include git to support build from remote source

### DIFF
--- a/20.10/dind/Dockerfile
+++ b/20.10/dind/Dockerfile
@@ -6,6 +6,8 @@
 
 FROM docker:20.10
 
+# git is installed in a separate layer to allow sharing between the "dind" and "git" variants
+RUN apk add --no-cache git
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN set -eux; \
 	apk add --no-cache \

--- a/20.10/git/Dockerfile
+++ b/20.10/git/Dockerfile
@@ -6,4 +6,5 @@
 
 FROM docker:20.10
 
+# git is installed in a separate layer to allow sharing between the "dind" and "git" variants
 RUN apk add --no-cache git

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -1,5 +1,9 @@
 FROM docker:{{ env.version }}
 
+{{ if ["19.03", "19.03-rc", "20.10-rc"] | index(env.version) | not then ( -}}
+# git is installed in a separate layer to allow sharing between the "dind" and "git" variants
+RUN apk add --no-cache git
+{{ ) else "" end -}}
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN set -eux; \
 	apk add --no-cache \

--- a/Dockerfile-git.template
+++ b/Dockerfile-git.template
@@ -1,3 +1,6 @@
 FROM docker:{{ env.version }}
 
+{{ if ["19.03", "19.03-rc", "20.10-rc"] | index(env.version) | not then ( -}}
+# git is installed in a separate layer to allow sharing between the "dind" and "git" variants
+{{ ) else "" end -}}
 RUN apk add --no-cache git


### PR DESCRIPTION
This patch installs git in the "dind" variants of the image, to allow using `docker build` to build from a remote source.

This change adds ~13MB to the image size (after decompressing). Below is a list of image variants ("dind-git" is the local build) for comparison:

    REPOSITORY    TAG              IMAGE ID       CREATED          SIZE
    docker        20.10-dind-git   35ca9f3f5cbf   10 seconds ago   270MB
    docker        20.10-dind       d1a6345c23f3   2 weeks ago      257MB
    docker        20.10-git        5675ce6408db   2 weeks ago      253MB
    docker        20.10            6e081696197d   2 weeks ago      241MB

And ~6MB compressed (docker save <image> | gzip > file.tgz)

    -rw-r--r--  1 sebastiaan  staff    76M Feb 17 17:20 before.tgz
    -rw-r--r--  1 sebastiaan  staff    82M Feb 17 17:21 after.tgz

Installing git is done in a separate RUN, so that the layer can be shared between the "20.10-git" and "20.10-dind" variants of the image in situations where both variants are used on the same machine.
