### PR TITLE
Windows update

### DIFF
--- a/20.10/windows/windowsservercore-1809/Dockerfile
+++ b/20.10/windows/windowsservercore-1809/Dockerfile
@@ -1,0 +1,40 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:1809
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\docker;{1}' -f $env:ProgramFiles, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV DOCKER_VERSION 20.10.6
+ENV DOCKER_URL https://download.docker.com/win/static/stable/x86_64/docker-20.10.6.zip
+# TODO ENV DOCKER_SHA256
+# https://github.com/docker/docker-ce/blob/5b073ee2cf564edee5adca05eee574142f7627bb/components/packaging/static/hash_files !!
+# (no SHA file artifacts on download.docker.com yet as of 2017-06-07 though)
+
+RUN Write-Host ('Downloading {0} ...' -f $env:DOCKER_URL); \
+	Invoke-WebRequest -Uri $env:DOCKER_URL -OutFile 'docker.zip'; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive docker.zip -DestinationPath $env:ProgramFiles; \
+# (this archive has a "docker/..." directory in it already)
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item @( \
+			'docker.zip', \
+			('{0}\docker\dockerd.exe' -f $env:ProgramFiles) \
+		) -Force; \
+	\
+	Write-Host 'Verifying install ("docker --version") ...'; \
+	docker --version; \
+	\
+	Write-Host 'Complete.';

--- a/Dockerfile-windows-servercore.template
+++ b/Dockerfile-windows-servercore.template
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:%%TAG%%
+FROM mcr.microsoft.com/windows/{{ env.windowsVariant }}:{{ env.windowsRelease }}
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -9,15 +9,14 @@ RUN $newPath = ('{0}\docker;{1}' -f $env:ProgramFiles, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV DOCKER_CHANNEL %%DOCKER-CHANNEL%%
-ENV DOCKER_VERSION %%DOCKER-VERSION%%
+ENV DOCKER_VERSION {{ .version }}
+ENV DOCKER_URL {{ .arches["windows-amd64"].dockerUrl }}
 # TODO ENV DOCKER_SHA256
 # https://github.com/docker/docker-ce/blob/5b073ee2cf564edee5adca05eee574142f7627bb/components/packaging/static/hash_files !!
 # (no SHA file artifacts on download.docker.com yet as of 2017-06-07 though)
 
-RUN $url = ('https://download.docker.com/win/static/{0}/x86_64/docker-{1}.zip' -f $env:DOCKER_CHANNEL, $env:DOCKER_VERSION); \
-	Write-Host ('Downloading {0} ...' -f $url); \
-	Invoke-WebRequest -Uri $url -OutFile 'docker.zip'; \
+RUN Write-Host ('Downloading {0} ...' -f $env:DOCKER_URL); \
+	Invoke-WebRequest -Uri $env:DOCKER_URL -OutFile 'docker.zip'; \
 	\
 	Write-Host 'Expanding ...'; \
 	Expand-Archive docker.zip -DestinationPath $env:ProgramFiles; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -23,7 +23,7 @@ RUN set -eux; \
 {{
 	[
 		.arches | to_entries[]
-		| select(.value.dockerUrl)
+		| select(.value.dockerUrl and (.key | startswith("windows-") | not))
 		| .key as $bashbrewArch
 		| (
 			{

--- a/versions.json
+++ b/versions.json
@@ -66,6 +66,9 @@
       },
       "arm64v8": {
         "dockerUrl": "https://download.docker.com/linux/static/stable/aarch64/docker-20.10.6.tgz"
+      },
+      "windows-amd64": {
+        "dockerUrl": "https://download.docker.com/win/static/stable/x86_64/docker-20.10.6.zip"
       }
     },
     "dindCommit": "42b1175eda071c0e9121e1d64345928384a93df1",
@@ -73,7 +76,8 @@
       "",
       "dind",
       "dind-rootless",
-      "git"
+      "git",
+      "windows/windowsservercore-1809"
     ],
     "version": "20.10.6"
   },


### PR DESCRIPTION
Hi guys,
I've needed to use docker on windows image and I've noticed the one in the repo is quite a bit old now. 

## Changes
- So I've updated the windows base image in the template
- and explicitly added windows version based on current ltsc2019.

Do you think it is welcomed change? 

I think the template would deserve the update.
And about the explicite file, I'm not sure if it won't collide with the ci here in the repo.