### PR TITLE
add workaround for non-static `ctr` binary in docker 20.10.8

### DIFF
--- a/20.10/Dockerfile
+++ b/20.10/Dockerfile
@@ -8,6 +8,8 @@ FROM alpine:3.13
 
 RUN apk add --no-cache \
 		ca-certificates \
+# Workaround for golang not producing a static ctr binary on Go 1.15 and up https://github.com/containerd/containerd/issues/5824
+		libc6-compat \
 # DOCKER_HOST=ssh://... -- https://github.com/docker/cli/pull/1014
 		openssh-client
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -2,6 +2,10 @@ FROM alpine:{{ .alpine }}
 
 RUN apk add --no-cache \
 		ca-certificates \
+{{ if ["19.03", "19.03-rc", "20.10-rc"] | index(env.version) | not then ( -}}
+# Workaround for golang not producing a static ctr binary on Go 1.15 and up https://github.com/containerd/containerd/issues/5824
+		libc6-compat \
+{{ ) else "" end -}}
 # DOCKER_HOST=ssh://... -- https://github.com/docker/cli/pull/1014
 		openssh-client
 


### PR DESCRIPTION
### Add libc6-compat as workaround for non-static ctr binary

When compiling containerd's ctr on Go 1.15 or up, the produced binary
is not fully static, causing it to fail on Alpine:

    ldd /usr/local/bin/ctr
        /lib64/ld-linux-x86-64.so.2 (0x7f1970417000)

This issue is tracked in containerd/containerd#5824.
Until it's fixed, adding `libc6-compat` as a workaround:
https://pkgs.alpinelinux.org/package/edge/main/x86_64/libc6-compat

Note that there's an alternative `gcompat` package, which provides similar
functionality (and also resolves the issue), but unlike `libc6-compat`, that
package is a `community` package, is larger, and has more dependencies:
https://pkgs.alpinelinux.org/package/edge/community/x86_64/gcompat

### WIP: test docker 20.10.8 (from staging)

Update the Dockerfile with Docker 20.10.8, which is currently on download-stage.docker.com
