### PR TITLE
Use full version in FROM lines

### DIFF
--- a/19.03-rc/dind-rootless/Dockerfile
+++ b/19.03-rc/dind-rootless/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM docker:19.03-rc-dind
+FROM docker:19.03.13-beta2-dind
 
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1

--- a/19.03-rc/dind/Dockerfile
+++ b/19.03-rc/dind/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM docker:19.03-rc
+FROM docker:19.03.13-beta2
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN set -eux; \

--- a/19.03-rc/git/Dockerfile
+++ b/19.03-rc/git/Dockerfile
@@ -4,6 +4,6 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM docker:19.03-rc
+FROM docker:19.03.13-beta2
 
 RUN apk add --no-cache git

--- a/19.03/dind-rootless/Dockerfile
+++ b/19.03/dind-rootless/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM docker:19.03-dind
+FROM docker:19.03.15-dind
 
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1

--- a/19.03/dind/Dockerfile
+++ b/19.03/dind/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM docker:19.03
+FROM docker:19.03.15
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN set -eux; \

--- a/19.03/git/Dockerfile
+++ b/19.03/git/Dockerfile
@@ -4,6 +4,6 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM docker:19.03
+FROM docker:19.03.15
 
 RUN apk add --no-cache git

--- a/20.10-rc/dind-rootless/Dockerfile
+++ b/20.10-rc/dind-rootless/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM docker:20.10-rc-dind
+FROM docker:20.10.0-rc2-dind
 
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1

--- a/20.10-rc/dind/Dockerfile
+++ b/20.10-rc/dind/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM docker:20.10-rc
+FROM docker:20.10.0-rc2
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN set -eux; \

--- a/20.10-rc/git/Dockerfile
+++ b/20.10-rc/git/Dockerfile
@@ -4,6 +4,6 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM docker:20.10-rc
+FROM docker:20.10.0-rc2
 
 RUN apk add --no-cache git

--- a/20.10/dind-rootless/Dockerfile
+++ b/20.10/dind-rootless/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM docker:20.10-dind
+FROM docker:20.10.7-dind
 
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1

--- a/20.10/dind/Dockerfile
+++ b/20.10/dind/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM docker:20.10
+FROM docker:20.10.7
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN set -eux; \

--- a/20.10/git/Dockerfile
+++ b/20.10/git/Dockerfile
@@ -4,6 +4,6 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM docker:20.10
+FROM docker:20.10.7
 
 RUN apk add --no-cache git

--- a/Dockerfile-dind-rootless.template
+++ b/Dockerfile-dind-rootless.template
@@ -1,4 +1,4 @@
-FROM docker:{{ env.version }}-dind
+FROM docker:{{ .version }}-dind
 
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -1,4 +1,4 @@
-FROM docker:{{ env.version }}
+FROM docker:{{ .version }}
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN set -eux; \

--- a/Dockerfile-git.template
+++ b/Dockerfile-git.template
@@ -1,3 +1,3 @@
-FROM docker:{{ env.version }}
+FROM docker:{{ .version }}
 
 RUN apk add --no-cache git


### PR DESCRIPTION
Perhaps there is a specific reason for not doing this, but when trying to
build the image locally, I made the mistake of not tagging a version without
the patch release, and ended up with a `-dind` image that was based on the
previous version;

    docker build -t docker:20.10.8 ./20.10/
    docker build -t docker:20.10.8-dind ./20.20/dind/

Using the full version makes sure that the base image is the expected (current)
version.
