### PR TITLE
Drop arm32v6 and arm32v7 builds for now

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -74,6 +74,9 @@ versionArches() {
 				.[env.version].arches | to_entries[]
 				| select(.value.'"$selector"')
 				| .key
+				# all arm32 builds are broken:
+				# https://github.com/docker-library/docker/issues/260
+				| select(startswith("arm32") | not)
 			' versions.json | sort
 		) \
 		<(xargs -n1 <<<"$parentArches" | sort)


### PR DESCRIPTION
[arm32v6](https://doi-janky.infosiftr.net/job/multiarch/view/images/view/docker/job/arm32v6/job/docker/): still broken
```console
+ bashbrew build docker:20.10.8
...
+ dockerd --version
Bus error (core dumped)

+ bashbrew build docker:19.03.15
...
+ dockerd --version
Segmentation fault (core dumped)
```

[arm32v7](https://doi-janky.infosiftr.net/job/multiarch/view/images/view/docker/job/arm32v7/job/docker/): still broken
```console
+ Bus error docker:20.10.8
...
+ dockerd --version
Illegal instruction (core dumped)

+ bashbrew build docker:19.03.15
...
+ dockerd --version
Segmentation fault (core dumped)
```

ref https://github.com/docker-library/docker/issues/260
closes https://github.com/docker-library/docker/issues/325

cc @thaJeztah anything @tianon and I can do to help debug the upstream `docker` builds for `arm32*`?