### PR TITLE
Add suite aliases ("alpine3.13")

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -176,10 +176,11 @@ for version; do
 		variantAliases=( "${versionAliases[@]/%/${variant:+-$variant}}" )
 		variantAliases=( "${variantAliases[@]//latest-/}" )
 
-		if [[ "$variant" != windowsservercore* ]]; then
+		if [ "$variant" = '' ] || [ "$variant" = 'dind' ]; then
 			parent="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/Dockerfile")"
 			alpine="${parent#*:}" # "3.14"
-			suiteAliases=( "${variantAliases[@]/%/-alpine$alpine}" )
+			suiteAliases=( "${variantAliases[0]}" ) # only "X.Y.Z-foo"
+			suiteAliases=( "${suiteAliases[@]/%/-alpine$alpine}" )
 			suiteAliases=( "${suiteAliases[@]//latest-/}" )
 			variantAliases+=( "${suiteAliases[@]}" )
 		fi

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -176,6 +176,14 @@ for version; do
 		variantAliases=( "${versionAliases[@]/%/${variant:+-$variant}}" )
 		variantAliases=( "${variantAliases[@]//latest-/}" )
 
+		if [[ "$variant" != windowsservercore* ]]; then
+			parent="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/Dockerfile")"
+			alpine="${parent#*:}" # "3.14"
+			suiteAliases=( "${variantAliases[@]/%/-alpine$alpine}" )
+			suiteAliases=( "${suiteAliases[@]//latest-/}" )
+			variantAliases+=( "${suiteAliases[@]}" )
+		fi
+
 		sharedTags=()
 		if [[ "$variant" == windowsservercore* ]]; then
 			sharedTags=( "${versionAliases[@]/%/-windowsservercore}" )


### PR DESCRIPTION
This is a prerequisite of something like #317 to ensure users who can't update Docker for one reason or another have an escape hatch (which also means they won't update Docker-in-Docker either, but they can't have everything). ￼:sweat_smile:

<details>
<summary>Diff:</summary>

```diff
$ diff -u <(bashbrew cat docker) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2021-08-20 16:10:13.849510802 -0700
+++ /dev/fd/62	2021-08-20 16:10:13.849510802 -0700
@@ -1,22 +1,22 @@
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon), Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 20.10.8, 20.10, 20, latest
+Tags: 20.10.8, 20.10, 20, latest, 20.10.8-alpine3.13, 20.10-alpine3.13, 20-alpine3.13, alpine3.13
 Architectures: amd64, arm64v8
 GitCommit: 75e26edc9ea7fff4aa3212fafa5966f4d6b00022
 Directory: 20.10
 
-Tags: 20.10.8-dind, 20.10-dind, 20-dind, dind
+Tags: 20.10.8-dind, 20.10-dind, 20-dind, dind, 20.10.8-dind-alpine3.13, 20.10-dind-alpine3.13, 20-dind-alpine3.13, dind-alpine3.13
 Architectures: amd64, arm64v8
 GitCommit: 8baa881aab85f8398d2edbbcc0da4bd1f556dd98
 Directory: 20.10/dind
 
-Tags: 20.10.8-dind-rootless, 20.10-dind-rootless, 20-dind-rootless, dind-rootless
+Tags: 20.10.8-dind-rootless, 20.10-dind-rootless, 20-dind-rootless, dind-rootless, 20.10.8-dind-rootless-alpine3.13, 20.10-dind-rootless-alpine3.13, 20-dind-rootless-alpine3.13, dind-rootless-alpine3.13
 Architectures: amd64, arm64v8
 GitCommit: 83e4de3bc2aac346e2f76129b1a3a556c1e1bb95
 Directory: 20.10/dind-rootless
 
-Tags: 20.10.8-git, 20.10-git, 20-git, git
+Tags: 20.10.8-git, 20.10-git, 20-git, git, 20.10.8-git-alpine3.13, 20.10-git-alpine3.13, 20-git-alpine3.13, git-alpine3.13
 Architectures: amd64, arm64v8
 GitCommit: 387e351394bfad74bceebf8303c6c8e39c3d4ed4
 Directory: 20.10/git
@@ -28,21 +28,21 @@
 Directory: 20.10/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 19.03.15, 19.03, 19
+Tags: 19.03.15, 19.03, 19, 19.03.15-alpine3.13, 19.03-alpine3.13, 19-alpine3.13
 Architectures: amd64, arm64v8
 GitCommit: 835c371c516ebdf67adc0c76bbfb38bf9d3e586c
 Directory: 19.03
 
-Tags: 19.03.15-dind, 19.03-dind, 19-dind
+Tags: 19.03.15-dind, 19.03-dind, 19-dind, 19.03.15-dind-alpine3.13, 19.03-dind-alpine3.13, 19-dind-alpine3.13
 Architectures: amd64, arm64v8
 GitCommit: 8baa881aab85f8398d2edbbcc0da4bd1f556dd98
 Directory: 19.03/dind
 
-Tags: 19.03.15-dind-rootless, 19.03-dind-rootless, 19-dind-rootless
+Tags: 19.03.15-dind-rootless, 19.03-dind-rootless, 19-dind-rootless, 19.03.15-dind-rootless-alpine3.13, 19.03-dind-rootless-alpine3.13, 19-dind-rootless-alpine3.13
 GitCommit: 835c371c516ebdf67adc0c76bbfb38bf9d3e586c
 Directory: 19.03/dind-rootless
 
-Tags: 19.03.15-git, 19.03-git, 19-git
+Tags: 19.03.15-git, 19.03-git, 19-git, 19.03.15-git-alpine3.13, 19.03-git-alpine3.13, 19-git-alpine3.13
 Architectures: amd64, arm64v8
 GitCommit: 12d1c2763b54d29137ec448a3e4ad1a9aefae1a0
 Directory: 19.03/git
```

</details>

I _really_ don't like how verbose this gets (we've been so clean up until now), so I'd love to find an alternative...  Maybe we only provide _some_ of these aliases?  (How do we choose which ones?)