### PR TITLE
Add "buildx" and "compose" CLI plugins (for supported architectures of each)

### DIFF
--- a/20.10/Dockerfile
+++ b/20.10/Dockerfile
@@ -55,6 +55,86 @@ RUN set -eux; \
 	dockerd --version; \
 	docker --version
 
+ENV DOCKER_BUILDX_VERSION 0.8.2
+RUN set -eux; \
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		'x86_64') \
+			url='https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64'; \
+			sha256='c64de4f3c30f7a73ff9db637660c7aa0f00234368105b0a09fa8e24eebe910c3'; \
+			;; \
+		'armhf') \
+			url='https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-arm-v6'; \
+			sha256='d0e5d19cd67ea7a351e3bfe1de96f3d583a5b80f1bbadd61f7adcd61b147e5f5'; \
+			;; \
+		'armv7') \
+			url='https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-arm-v7'; \
+			sha256='b5bb1e28e9413a75b2600955c486870aafd234f69953601eecc3664bd3af7463'; \
+			;; \
+		'aarch64') \
+			url='https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-arm64'; \
+			sha256='304d3d9822c75f98ad9cf57f0c234bcf326bbb96d791d551728cadd72a7a377f'; \
+			;; \
+		'ppc64le') \
+			url='https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-ppc64le'; \
+			sha256='32b317d86c700d920468f162f93ae2282777da556ee49b4329f6c72ee2b11b85'; \
+			;; \
+		'riscv64') \
+			url='https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-riscv64'; \
+			sha256='76d5fcf92ffa31b3e470d8ec1ab11f7b6997729e5c94d543fec765ad79ad0630'; \
+			;; \
+		's390x') \
+			url='https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-s390x'; \
+			sha256='ec4bb6f271f38dca5a377a70be24ee2108a85f6e6ba511ad3b805c4f1602a0d2'; \
+			;; \
+		*) echo >&2 "warning: unsupported buildx architecture ($apkArch); skipping"; exit 0 ;; \
+	esac; \
+	plugin='/usr/libexec/docker/cli-plugins/docker-buildx'; \
+	mkdir -p "$(dirname "$plugin")"; \
+	wget -O "$plugin" "$url"; \
+	echo "$sha256 *$plugin" | sha256sum -c -; \
+	chmod +x "$plugin"; \
+	docker buildx version
+
+ENV DOCKER_COMPOSE_VERSION 2.5.0
+RUN set -eux; \
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		'x86_64') \
+			url='https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-linux-x86_64'; \
+			sha256='6296d17268c77a7159f57f04ed26dd2989f909c58cca4d44d1865f28bd27dd67'; \
+			;; \
+		'armhf') \
+			url='https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-linux-armv6'; \
+			sha256='92b423e2c4d0ca0a979d7b6a4fb13707612f8fa19b900bc6cd1c2cf83f2780c5'; \
+			;; \
+		'armv7') \
+			url='https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-linux-armv7'; \
+			sha256='d728dcbe5e20103e9b025efdbb6bfbca9ea9866851e669f7775fe3ebb7ab945c'; \
+			;; \
+		'aarch64') \
+			url='https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-linux-aarch64'; \
+			sha256='7efc61cc85fe712f14f04a6886d1481c96fe958be265f67482583b4b713b6a22'; \
+			;; \
+		'ppc64le') \
+			url='https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-linux-ppc64le'; \
+			sha256='e40af00a5f3ef87d31372f949134411b574042b8c055b2e5da12b92192405cb6'; \
+			;; \
+		's390x') \
+			url='https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-linux-s390x'; \
+			sha256='c36e48910f095d07d582b69363fb3f902bb6fab9e2bd3d5ed82a67d1b2279a39'; \
+			;; \
+		*) echo >&2 "warning: unsupported compose architecture ($apkArch); skipping"; exit 0 ;; \
+	esac; \
+	plugin='/usr/libexec/docker/cli-plugins/docker-compose'; \
+	mkdir -p "$(dirname "$plugin")"; \
+	wget -O "$plugin" "$url"; \
+	echo "$sha256 *$plugin" | sha256sum -c -; \
+	chmod +x "$plugin"; \
+	ln -sv "$plugin" /usr/local/bin/; \
+	docker-compose --version; \
+	docker compose version
+
 COPY modprobe.sh /usr/local/bin/modprobe
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -18,6 +18,22 @@ ENV DOCKER_VERSION {{ .version }}
 # https://github.com/docker/docker-ce/blob/5b073ee2cf564edee5adca05eee574142f7627bb/components/packaging/static/hash_files !!
 # (no SHA file artifacts on download.docker.com yet as of 2017-06-07 though)
 
+{{
+	def apkArch:
+		{
+			# https://dl-cdn.alpinelinux.org/alpine/edge/main/
+			# https://wiki.alpinelinux.org/wiki/Architecture#Alpine_Hardware_Architecture_.28.22arch.22.29_Support
+			# https://pkgs.alpinelinux.org/packages ("Arch" dropdown)
+			amd64: "x86_64",
+			arm32v6: "armhf",
+			arm32v7: "armv7",
+			arm64v8: "aarch64",
+			i386: "x86",
+			ppc64le: "ppc64le",
+			riscv64: "riscv64",
+			s390x: "s390x",
+		}[.]
+-}}
 RUN set -eux; \
 	\
 	apkArch="$(apk --print-arch)"; \
@@ -25,18 +41,10 @@ RUN set -eux; \
 {{
 	[
 		.arches | to_entries[]
-		| select(.value.dockerUrl and (.key | startswith("windows-") | not))
 		| .key as $bashbrewArch
-		| (
-			{
-				amd64: "x86_64",
-				arm32v6: "armhf",
-				arm32v7: "armv7",
-				arm64v8: "aarch64",
-			}
-			| .[$bashbrewArch] // $bashbrewArch
-		) as $apkArch
+		| ($bashbrewArch | apkArch) as $apkArch
 		| .value
+		| select($apkArch and .dockerUrl)
 		| (
 -}}
 		{{ $apkArch | @sh }}) \
@@ -60,6 +68,52 @@ RUN set -eux; \
 	\
 	dockerd --version; \
 	docker --version
+{{
+	{
+		buildx: .buildx,
+		compose: .compose,
+	}
+	| to_entries | map(
+		.key as $key | .value | (
+-}}
+
+ENV DOCKER_{{ $key | ascii_upcase }}_VERSION {{ .version }}
+RUN set -eux; \
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+{{
+			.arches | to_entries | map(
+				.key as $bashbrewArch
+				| ($bashbrewArch | apkArch) as $apkArch
+				| .value
+				| select($apkArch and .url and .sha256)
+				| (
+-}}
+		{{ $apkArch | @sh }}) \
+			url={{ .url | @sh }}; \
+			sha256={{ .sha256 | @sh }}; \
+			;; \
+{{
+				)
+			) | add
+-}}
+		*) echo >&2 "warning: unsupported {{ $key }} architecture ($apkArch); skipping"; exit 0 ;; \
+	esac; \
+	plugin='/usr/libexec/docker/cli-plugins/docker-{{ $key }}'; \
+	mkdir -p "$(dirname "$plugin")"; \
+	wget -O "$plugin" "$url"; \
+	echo "$sha256 *$plugin" | sha256sum -c -; \
+	chmod +x "$plugin"; \
+{{ if $key == "compose" then ( -}}
+	ln -sv "$plugin" /usr/local/bin/; \
+	docker-{{ $key }} --version; \
+{{ ) else "" end -}}
+	docker {{ $key }} version
+{{
+		)
+	)
+	| add
+-}}
 
 COPY modprobe.sh /usr/local/bin/modprobe
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/versions.json
+++ b/versions.json
@@ -20,6 +20,106 @@
         "dockerUrl": "https://download.docker.com/win/static/stable/x86_64/docker-20.10.15.zip"
       }
     },
+    "buildx": {
+      "arches": {
+        "amd64": {
+          "file": "buildx-v0.8.2.linux-amd64",
+          "sha256": "c64de4f3c30f7a73ff9db637660c7aa0f00234368105b0a09fa8e24eebe910c3",
+          "url": "https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64"
+        },
+        "arm32v6": {
+          "file": "buildx-v0.8.2.linux-arm-v6",
+          "sha256": "d0e5d19cd67ea7a351e3bfe1de96f3d583a5b80f1bbadd61f7adcd61b147e5f5",
+          "url": "https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-arm-v6"
+        },
+        "arm32v7": {
+          "file": "buildx-v0.8.2.linux-arm-v7",
+          "sha256": "b5bb1e28e9413a75b2600955c486870aafd234f69953601eecc3664bd3af7463",
+          "url": "https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-arm-v7"
+        },
+        "arm64v8": {
+          "file": "buildx-v0.8.2.linux-arm64",
+          "sha256": "304d3d9822c75f98ad9cf57f0c234bcf326bbb96d791d551728cadd72a7a377f",
+          "url": "https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-arm64"
+        },
+        "ppc64le": {
+          "file": "buildx-v0.8.2.linux-ppc64le",
+          "sha256": "32b317d86c700d920468f162f93ae2282777da556ee49b4329f6c72ee2b11b85",
+          "url": "https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-ppc64le"
+        },
+        "riscv64": {
+          "file": "buildx-v0.8.2.linux-riscv64",
+          "sha256": "76d5fcf92ffa31b3e470d8ec1ab11f7b6997729e5c94d543fec765ad79ad0630",
+          "url": "https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-riscv64"
+        },
+        "s390x": {
+          "file": "buildx-v0.8.2.linux-s390x",
+          "sha256": "ec4bb6f271f38dca5a377a70be24ee2108a85f6e6ba511ad3b805c4f1602a0d2",
+          "url": "https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-s390x"
+        },
+        "windows-amd64": {
+          "file": "buildx-v0.8.2.windows-amd64.exe",
+          "sha256": "abd54d5a589c7745b67990b4fdbd489c922864e3725353faf6859ceed835dd4a",
+          "url": "https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.windows-amd64.exe"
+        },
+        "windows-arm64v8": {
+          "file": "buildx-v0.8.2.windows-arm64.exe",
+          "sha256": "8fe575d9346d30e97240ee0dd85c22b5974e8ee898a5fd26ab0d7e6792bc3cf8",
+          "url": "https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.windows-arm64.exe"
+        }
+      },
+      "version": "0.8.2"
+    },
+    "compose": {
+      "arches": {
+        "amd64": {
+          "file": "docker-compose-linux-x86_64",
+          "sha256": "6296d17268c77a7159f57f04ed26dd2989f909c58cca4d44d1865f28bd27dd67",
+          "url": "https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-linux-x86_64"
+        },
+        "arm32v6": {
+          "file": "docker-compose-linux-armv6",
+          "sha256": "92b423e2c4d0ca0a979d7b6a4fb13707612f8fa19b900bc6cd1c2cf83f2780c5",
+          "url": "https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-linux-armv6"
+        },
+        "arm32v7": {
+          "file": "docker-compose-linux-armv7",
+          "sha256": "d728dcbe5e20103e9b025efdbb6bfbca9ea9866851e669f7775fe3ebb7ab945c",
+          "url": "https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-linux-armv7"
+        },
+        "arm64v8": {
+          "file": "docker-compose-linux-aarch64",
+          "sha256": "7efc61cc85fe712f14f04a6886d1481c96fe958be265f67482583b4b713b6a22",
+          "url": "https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-linux-aarch64"
+        },
+        "darwin-amd64": {
+          "file": "docker-compose-darwin-x86_64",
+          "sha256": "230e50b7f4bfc1705adb60cc5645df37a09873882230d60cc1ae20ba3099c521",
+          "url": "https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-darwin-x86_64"
+        },
+        "darwin-arm64v8": {
+          "file": "docker-compose-darwin-aarch64",
+          "sha256": "6b2d97d7b48c66930d1c9e4b81e4526e059b68a18c98d4ff862b4ca28f345c9a",
+          "url": "https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-darwin-aarch64"
+        },
+        "ppc64le": {
+          "file": "docker-compose-linux-ppc64le",
+          "sha256": "e40af00a5f3ef87d31372f949134411b574042b8c055b2e5da12b92192405cb6",
+          "url": "https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-linux-ppc64le"
+        },
+        "s390x": {
+          "file": "docker-compose-linux-s390x",
+          "sha256": "c36e48910f095d07d582b69363fb3f902bb6fab9e2bd3d5ed82a67d1b2279a39",
+          "url": "https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-linux-s390x"
+        },
+        "windows-amd64": {
+          "file": "docker-compose-windows-x86_64.exe",
+          "sha256": "83b4ce5911505edc7164650e9edf480e042baf6cb45293297ad57592d56947db",
+          "url": "https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-windows-x86_64.exe"
+        }
+      },
+      "version": "2.5.0"
+    },
     "dindCommit": "42b1175eda071c0e9121e1d64345928384a93df1",
     "variants": [
       "",


### PR DESCRIPTION
- Closes #303
- Closes #355
- Closes https://github.com/docker/roadmap/issues/322

(I don't actually have permission for this to auto-close https://github.com/docker/roadmap/issues/322, so maybe someone like @thaJeztah or @chris-crone can do the honors once we get this in.)

Refs:
- #18
- #30
- #42
- #156
- #243
- #313
- https://github.com/docker/compose/issues/8871
- https://github.com/docker/roadmap/issues/256
- https://github.com/docker/docker-ce-packaging/pull/309

As a warning, this does very severely bloat the size of the Docker images (something like 100MiB more), but given these are part of the "Docker Experience" I think it makes sense. :see_no_evil: