### PR TITLE
Swap netgo prep to check instead of create

### DIFF
--- a/20.10/cli/Dockerfile
+++ b/20.10/cli/Dockerfile
@@ -13,11 +13,11 @@ RUN apk add --no-cache \
 # DOCKER_HOST=ssh://... -- https://github.com/docker/cli/pull/1014
 		openssh-client
 
-# set up nsswitch.conf for Go's "netgo" implementation (which Docker explicitly uses)
-# - https://github.com/docker/docker-ce/blob/v17.09.0-ce/components/engine/hack/make.sh#L149
-# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# ensure that nsswitch.conf is set up for Go's "netgo" implementation (which Docker explicitly uses)
+# - https://github.com/moby/moby/blob/v20.10.21/hack/make.sh#L115
+# - https://github.com/golang/go/blob/go1.19.3/src/net/conf.go#L227-L303
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+RUN [ -e /etc/nsswitch.conf ] && grep '^hosts: files dns' /etc/nsswitch.conf
 
 ENV DOCKER_VERSION 20.10.21
 

--- a/22.06-rc/cli/Dockerfile
+++ b/22.06-rc/cli/Dockerfile
@@ -13,11 +13,11 @@ RUN apk add --no-cache \
 # DOCKER_HOST=ssh://... -- https://github.com/docker/cli/pull/1014
 		openssh-client
 
-# set up nsswitch.conf for Go's "netgo" implementation (which Docker explicitly uses)
-# - https://github.com/docker/docker-ce/blob/v17.09.0-ce/components/engine/hack/make.sh#L149
-# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# ensure that nsswitch.conf is set up for Go's "netgo" implementation (which Docker explicitly uses)
+# - https://github.com/moby/moby/blob/v20.10.21/hack/make.sh#L115
+# - https://github.com/golang/go/blob/go1.19.3/src/net/conf.go#L227-L303
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+RUN [ -e /etc/nsswitch.conf ] && grep '^hosts: files dns' /etc/nsswitch.conf
 
 ENV DOCKER_VERSION 22.06.0-beta.0
 

--- a/Dockerfile-cli.template
+++ b/Dockerfile-cli.template
@@ -8,11 +8,11 @@ RUN apk add --no-cache \
 # DOCKER_HOST=ssh://... -- https://github.com/docker/cli/pull/1014
 		openssh-client
 
-# set up nsswitch.conf for Go's "netgo" implementation (which Docker explicitly uses)
-# - https://github.com/docker/docker-ce/blob/v17.09.0-ce/components/engine/hack/make.sh#L149
-# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# ensure that nsswitch.conf is set up for Go's "netgo" implementation (which Docker explicitly uses)
+# - https://github.com/moby/moby/blob/v20.10.21/hack/make.sh#L115
+# - https://github.com/golang/go/blob/go1.19.3/src/net/conf.go#L227-L303
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+RUN [ -e /etc/nsswitch.conf ] && grep '^hosts: files dns' /etc/nsswitch.conf
 
 ENV DOCKER_VERSION {{ .version }}
 


### PR DESCRIPTION
Also update the outdated links :see_no_evil: 

Alpine 3.16 has updated to [include an `nsswitch.conf`](https://git.alpinelinux.org/aports/commit/main/alpine-baselayout?h=3.16-stable&id=348653a9ba0701e8e968b3344e72313a9ef334e4).

```console
$ docker pull alpine:3.16
3.16: Pulling from library/alpine
Digest: sha256:b95359c2505145f16c6aa384f9cc74eeff78eb36d308ca4fd902eeeb0a0b161b
Status: Image is up to date for alpine:3.16
docker.io/library/alpine:3.16
$ docker build 20.10/cli/
Sending build context to Docker daemon  12.29kB
Step 1/15 : FROM alpine:3.16
 ---> bfe296a52501
Step 2/15 : RUN apk add --no-cache 		ca-certificates 		libc6-compat 		openssh-client
 ---> Running in cc5019465399
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
(1/9) Upgrading musl (1.2.3-r1 -> 1.2.3-r2)
(2/9) Installing ca-certificates (20220614-r0)
(3/9) Installing libc6-compat (1.2.3-r2)
(4/9) Installing openssh-keygen (9.0_p1-r2)
(5/9) Installing ncurses-terminfo-base (6.3_p20220521-r0)
(6/9) Installing ncurses-libs (6.3_p20220521-r0)
(7/9) Installing libedit (20210910.3.1-r0)
(8/9) Installing openssh-client-common (9.0_p1-r2)
(9/9) Installing openssh-client-default (9.0_p1-r2)
Executing busybox-1.35.0-r17.trigger
Executing ca-certificates-20220614-r0.trigger
OK: 11 MiB in 22 packages
Removing intermediate container cc5019465399
 ---> cf07598ac1ef
Step 3/15 : RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 ---> Running in b1d8fea5d459
The command '/bin/sh -c [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf' returned a non-zero code: 1
$ docker run -it --rm alpine:3.16 cat /etc/nsswitch.conf
# musl itself does not support NSS, however some third-party DNS
# implementations use the nsswitch.conf file to determine what
# policy to follow.
# Editing this file is not recommended.
hosts: files dns
```