### PR TITLE
prevent tls being disabled if _tls_generate_certs fails

### DIFF
--- a/20.10/dind/dockerd-entrypoint.sh
+++ b/20.10/dind/dockerd-entrypoint.sh
@@ -108,12 +108,11 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	esac
 
 	# add our default arguments
-	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
-		&& _tls_generate_certs "$DOCKER_TLS_CERTDIR" \
-		&& [ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ] \
-		&& [ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ] \
-		&& [ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ] \
-	; then
+	if [ -n "${DOCKER_TLS_CERTDIR:-}" ]; then
+		_tls_generate_certs "$DOCKER_TLS_CERTDIR"
+		[ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ]
+		[ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ]
+		[ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ]
 		# generate certs and use TLS if requested/possible (default in 19.03+)
 		set -- dockerd \
 			--host="$dockerSocket" \

--- a/23.0/dind/dockerd-entrypoint.sh
+++ b/23.0/dind/dockerd-entrypoint.sh
@@ -108,12 +108,11 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	esac
 
 	# add our default arguments
-	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
-		&& _tls_generate_certs "$DOCKER_TLS_CERTDIR" \
-		&& [ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ] \
-		&& [ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ] \
-		&& [ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ] \
-	; then
+	if [ -n "${DOCKER_TLS_CERTDIR:-}" ]; then
+		_tls_generate_certs "$DOCKER_TLS_CERTDIR"
+		[ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ]
+		[ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ]
+		[ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ]
 		# generate certs and use TLS if requested/possible (default in 19.03+)
 		set -- dockerd \
 			--host="$dockerSocket" \

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -108,12 +108,11 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	esac
 
 	# add our default arguments
-	if [ -n "${DOCKER_TLS_CERTDIR:-}" ] \
-		&& _tls_generate_certs "$DOCKER_TLS_CERTDIR" \
-		&& [ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ] \
-		&& [ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ] \
-		&& [ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ] \
-	; then
+	if [ -n "${DOCKER_TLS_CERTDIR:-}" ]; then
+		_tls_generate_certs "$DOCKER_TLS_CERTDIR"
+		[ -s "$DOCKER_TLS_CERTDIR/server/ca.pem" ]
+		[ -s "$DOCKER_TLS_CERTDIR/server/cert.pem" ]
+		[ -s "$DOCKER_TLS_CERTDIR/server/key.pem" ]
 		# generate certs and use TLS if requested/possible (default in 19.03+)
 		set -- dockerd \
 			--host="$dockerSocket" \


### PR DESCRIPTION
If TLS is requested (via `DOCKER_TLS_CERTDIR`) and the directory is not writable, then it should not silently disable TLS.

Fixes https://github.com/docker-library/docker/issues/397