### PR TITLE
Fix TLS typo, again, with vigor

### DIFF
--- a/20.10/dind/dockerd-entrypoint.sh
+++ b/20.10/dind/dockerd-entrypoint.sh
@@ -27,7 +27,7 @@ _tls_generate_certs() {
 	# if ca/key.pem, generate client public
 	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
 
-	if [ -s "$dir/server/ca.pem" ] && [ -s "$dir/server/cert.pem" ] && [ -s "$dir/server/key.pem" ] && [ ! "$dir/ca/key.pem" ]; then
+	if [ -s "$dir/server/ca.pem" ] && [ -s "$dir/server/cert.pem" ] && [ -s "$dir/server/key.pem" ] && [ ! -s "$dir/ca/key.pem" ]; then
 		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
 		return 0
 	fi

--- a/23.0/dind/dockerd-entrypoint.sh
+++ b/23.0/dind/dockerd-entrypoint.sh
@@ -27,7 +27,7 @@ _tls_generate_certs() {
 	# if ca/key.pem, generate client public
 	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
 
-	if [ -s "$dir/server/ca.pem" ] && [ -s "$dir/server/cert.pem" ] && [ -s "$dir/server/key.pem" ] && [ ! "$dir/ca/key.pem" ]; then
+	if [ -s "$dir/server/ca.pem" ] && [ -s "$dir/server/cert.pem" ] && [ -s "$dir/server/key.pem" ] && [ ! -s "$dir/ca/key.pem" ]; then
 		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
 		return 0
 	fi

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -27,7 +27,7 @@ _tls_generate_certs() {
 	# if ca/key.pem, generate client public
 	# (regenerating public certs every startup to account for SAN/IP changes and/or expiration)
 
-	if [ -s "$dir/server/ca.pem" ] && [ -s "$dir/server/cert.pem" ] && [ -s "$dir/server/key.pem" ] && [ ! "$dir/ca/key.pem" ]; then
+	if [ -s "$dir/server/ca.pem" ] && [ -s "$dir/server/cert.pem" ] && [ -s "$dir/server/key.pem" ] && [ ! -s "$dir/ca/key.pem" ]; then
 		openssl verify -CAfile "$dir/server/ca.pem" "$dir/server/cert.pem"
 		return 0
 	fi


### PR DESCRIPTION
This fixes the implementation in https://github.com/docker-library/docker/pull/402 to _actually_ work correctly.

Refs https://github.com/docker-library/docker/issues/401