### PR TITLE
Add "compose" and "buildx" CLI plugins to Windows CLI-only container

### DIFF
--- a/20.10/windows/windowsservercore-1809/Dockerfile
+++ b/20.10/windows/windowsservercore-1809/Dockerfile
@@ -38,3 +38,54 @@ RUN Write-Host ('Downloading {0} ...' -f $env:DOCKER_URL); \
 	docker --version; \
 	\
 	Write-Host 'Complete.';
+
+# https://github.com/docker-library/docker/issues/409#issuecomment-1462868414
+ENV DOCKER_BUILDX_VERSION 0.10.4
+ENV DOCKER_BUILDX_URL https://github.com/docker/buildx/releases/download/v0.10.4/buildx-v0.10.4.windows-amd64.exe
+ENV DOCKER_BUILDX_SHA256 e4bb5f70d98be80421bb26b78dd71fe9184a5f94315a6712f487e9eb252ad4f1
+RUN $dir = ('{0}\docker\cli-plugins' -f $env:ProgramFiles); \
+	Write-Host ('Creating {0} ...' -f $dir); \
+	New-Item -ItemType Directory $dir -Force; \
+	\
+	$plugin = ('{0}\docker-buildx.exe' -f $dir); \
+	Write-Host ('Downloading {0} ...' -f $env:DOCKER_BUILDX_URL); \
+	Invoke-WebRequest -Uri $env:DOCKER_BUILDX_URL -OutFile $plugin; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:DOCKER_BUILDX_SHA256); \
+	if ((Get-FileHash $plugin -Algorithm sha256).Hash -ne $env:DOCKER_BUILDX_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Verifying install ("docker buildx version") ...'; \
+	docker buildx version; \
+	\
+	Write-Host 'Complete.';
+ENV DOCKER_COMPOSE_VERSION 2.16.0
+ENV DOCKER_COMPOSE_URL https://github.com/docker/compose/releases/download/v2.16.0/docker-compose-windows-x86_64.exe
+ENV DOCKER_COMPOSE_SHA256 a35d1188e796dbda914ddb9677059c654b445aa2921066e0b556ca9906bb603c
+RUN $dir = ('{0}\docker\cli-plugins' -f $env:ProgramFiles); \
+	Write-Host ('Creating {0} ...' -f $dir); \
+	New-Item -ItemType Directory $dir -Force; \
+	\
+	$plugin = ('{0}\docker-compose.exe' -f $dir); \
+	Write-Host ('Downloading {0} ...' -f $env:DOCKER_COMPOSE_URL); \
+	Invoke-WebRequest -Uri $env:DOCKER_COMPOSE_URL -OutFile $plugin; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:DOCKER_COMPOSE_SHA256); \
+	if ((Get-FileHash $plugin -Algorithm sha256).Hash -ne $env:DOCKER_COMPOSE_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Verifying install ("docker compose version") ...'; \
+	docker compose version; \
+	\
+	$link = ('{0}\docker\docker-compose.exe' -f $env:ProgramFiles); \
+	Write-Host ('Linking {0} to {1} ...' -f $plugin, $link); \
+	New-Item -ItemType SymbolicLink -Path $link -Target $plugin; \
+	\
+	Write-Host 'Verifying install ("docker-compose --version") ...'; \
+	docker-compose --version; \
+	\
+	Write-Host 'Complete.';

--- a/20.10/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/20.10/windows/windowsservercore-ltsc2022/Dockerfile
@@ -38,3 +38,54 @@ RUN Write-Host ('Downloading {0} ...' -f $env:DOCKER_URL); \
 	docker --version; \
 	\
 	Write-Host 'Complete.';
+
+# https://github.com/docker-library/docker/issues/409#issuecomment-1462868414
+ENV DOCKER_BUILDX_VERSION 0.10.4
+ENV DOCKER_BUILDX_URL https://github.com/docker/buildx/releases/download/v0.10.4/buildx-v0.10.4.windows-amd64.exe
+ENV DOCKER_BUILDX_SHA256 e4bb5f70d98be80421bb26b78dd71fe9184a5f94315a6712f487e9eb252ad4f1
+RUN $dir = ('{0}\docker\cli-plugins' -f $env:ProgramFiles); \
+	Write-Host ('Creating {0} ...' -f $dir); \
+	New-Item -ItemType Directory $dir -Force; \
+	\
+	$plugin = ('{0}\docker-buildx.exe' -f $dir); \
+	Write-Host ('Downloading {0} ...' -f $env:DOCKER_BUILDX_URL); \
+	Invoke-WebRequest -Uri $env:DOCKER_BUILDX_URL -OutFile $plugin; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:DOCKER_BUILDX_SHA256); \
+	if ((Get-FileHash $plugin -Algorithm sha256).Hash -ne $env:DOCKER_BUILDX_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Verifying install ("docker buildx version") ...'; \
+	docker buildx version; \
+	\
+	Write-Host 'Complete.';
+ENV DOCKER_COMPOSE_VERSION 2.16.0
+ENV DOCKER_COMPOSE_URL https://github.com/docker/compose/releases/download/v2.16.0/docker-compose-windows-x86_64.exe
+ENV DOCKER_COMPOSE_SHA256 a35d1188e796dbda914ddb9677059c654b445aa2921066e0b556ca9906bb603c
+RUN $dir = ('{0}\docker\cli-plugins' -f $env:ProgramFiles); \
+	Write-Host ('Creating {0} ...' -f $dir); \
+	New-Item -ItemType Directory $dir -Force; \
+	\
+	$plugin = ('{0}\docker-compose.exe' -f $dir); \
+	Write-Host ('Downloading {0} ...' -f $env:DOCKER_COMPOSE_URL); \
+	Invoke-WebRequest -Uri $env:DOCKER_COMPOSE_URL -OutFile $plugin; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:DOCKER_COMPOSE_SHA256); \
+	if ((Get-FileHash $plugin -Algorithm sha256).Hash -ne $env:DOCKER_COMPOSE_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Verifying install ("docker compose version") ...'; \
+	docker compose version; \
+	\
+	$link = ('{0}\docker\docker-compose.exe' -f $env:ProgramFiles); \
+	Write-Host ('Linking {0} to {1} ...' -f $plugin, $link); \
+	New-Item -ItemType SymbolicLink -Path $link -Target $plugin; \
+	\
+	Write-Host 'Verifying install ("docker-compose --version") ...'; \
+	docker-compose --version; \
+	\
+	Write-Host 'Complete.';

--- a/23.0/windows/windowsservercore-1809/Dockerfile
+++ b/23.0/windows/windowsservercore-1809/Dockerfile
@@ -38,3 +38,54 @@ RUN Write-Host ('Downloading {0} ...' -f $env:DOCKER_URL); \
 	docker --version; \
 	\
 	Write-Host 'Complete.';
+
+# https://github.com/docker-library/docker/issues/409#issuecomment-1462868414
+ENV DOCKER_BUILDX_VERSION 0.10.4
+ENV DOCKER_BUILDX_URL https://github.com/docker/buildx/releases/download/v0.10.4/buildx-v0.10.4.windows-amd64.exe
+ENV DOCKER_BUILDX_SHA256 e4bb5f70d98be80421bb26b78dd71fe9184a5f94315a6712f487e9eb252ad4f1
+RUN $dir = ('{0}\docker\cli-plugins' -f $env:ProgramFiles); \
+	Write-Host ('Creating {0} ...' -f $dir); \
+	New-Item -ItemType Directory $dir -Force; \
+	\
+	$plugin = ('{0}\docker-buildx.exe' -f $dir); \
+	Write-Host ('Downloading {0} ...' -f $env:DOCKER_BUILDX_URL); \
+	Invoke-WebRequest -Uri $env:DOCKER_BUILDX_URL -OutFile $plugin; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:DOCKER_BUILDX_SHA256); \
+	if ((Get-FileHash $plugin -Algorithm sha256).Hash -ne $env:DOCKER_BUILDX_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Verifying install ("docker buildx version") ...'; \
+	docker buildx version; \
+	\
+	Write-Host 'Complete.';
+ENV DOCKER_COMPOSE_VERSION 2.16.0
+ENV DOCKER_COMPOSE_URL https://github.com/docker/compose/releases/download/v2.16.0/docker-compose-windows-x86_64.exe
+ENV DOCKER_COMPOSE_SHA256 a35d1188e796dbda914ddb9677059c654b445aa2921066e0b556ca9906bb603c
+RUN $dir = ('{0}\docker\cli-plugins' -f $env:ProgramFiles); \
+	Write-Host ('Creating {0} ...' -f $dir); \
+	New-Item -ItemType Directory $dir -Force; \
+	\
+	$plugin = ('{0}\docker-compose.exe' -f $dir); \
+	Write-Host ('Downloading {0} ...' -f $env:DOCKER_COMPOSE_URL); \
+	Invoke-WebRequest -Uri $env:DOCKER_COMPOSE_URL -OutFile $plugin; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:DOCKER_COMPOSE_SHA256); \
+	if ((Get-FileHash $plugin -Algorithm sha256).Hash -ne $env:DOCKER_COMPOSE_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Verifying install ("docker compose version") ...'; \
+	docker compose version; \
+	\
+	$link = ('{0}\docker\docker-compose.exe' -f $env:ProgramFiles); \
+	Write-Host ('Linking {0} to {1} ...' -f $plugin, $link); \
+	New-Item -ItemType SymbolicLink -Path $link -Target $plugin; \
+	\
+	Write-Host 'Verifying install ("docker-compose --version") ...'; \
+	docker-compose --version; \
+	\
+	Write-Host 'Complete.';

--- a/23.0/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/23.0/windows/windowsservercore-ltsc2022/Dockerfile
@@ -38,3 +38,54 @@ RUN Write-Host ('Downloading {0} ...' -f $env:DOCKER_URL); \
 	docker --version; \
 	\
 	Write-Host 'Complete.';
+
+# https://github.com/docker-library/docker/issues/409#issuecomment-1462868414
+ENV DOCKER_BUILDX_VERSION 0.10.4
+ENV DOCKER_BUILDX_URL https://github.com/docker/buildx/releases/download/v0.10.4/buildx-v0.10.4.windows-amd64.exe
+ENV DOCKER_BUILDX_SHA256 e4bb5f70d98be80421bb26b78dd71fe9184a5f94315a6712f487e9eb252ad4f1
+RUN $dir = ('{0}\docker\cli-plugins' -f $env:ProgramFiles); \
+	Write-Host ('Creating {0} ...' -f $dir); \
+	New-Item -ItemType Directory $dir -Force; \
+	\
+	$plugin = ('{0}\docker-buildx.exe' -f $dir); \
+	Write-Host ('Downloading {0} ...' -f $env:DOCKER_BUILDX_URL); \
+	Invoke-WebRequest -Uri $env:DOCKER_BUILDX_URL -OutFile $plugin; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:DOCKER_BUILDX_SHA256); \
+	if ((Get-FileHash $plugin -Algorithm sha256).Hash -ne $env:DOCKER_BUILDX_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Verifying install ("docker buildx version") ...'; \
+	docker buildx version; \
+	\
+	Write-Host 'Complete.';
+ENV DOCKER_COMPOSE_VERSION 2.16.0
+ENV DOCKER_COMPOSE_URL https://github.com/docker/compose/releases/download/v2.16.0/docker-compose-windows-x86_64.exe
+ENV DOCKER_COMPOSE_SHA256 a35d1188e796dbda914ddb9677059c654b445aa2921066e0b556ca9906bb603c
+RUN $dir = ('{0}\docker\cli-plugins' -f $env:ProgramFiles); \
+	Write-Host ('Creating {0} ...' -f $dir); \
+	New-Item -ItemType Directory $dir -Force; \
+	\
+	$plugin = ('{0}\docker-compose.exe' -f $dir); \
+	Write-Host ('Downloading {0} ...' -f $env:DOCKER_COMPOSE_URL); \
+	Invoke-WebRequest -Uri $env:DOCKER_COMPOSE_URL -OutFile $plugin; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:DOCKER_COMPOSE_SHA256); \
+	if ((Get-FileHash $plugin -Algorithm sha256).Hash -ne $env:DOCKER_COMPOSE_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Verifying install ("docker compose version") ...'; \
+	docker compose version; \
+	\
+	$link = ('{0}\docker\docker-compose.exe' -f $env:ProgramFiles); \
+	Write-Host ('Linking {0} to {1} ...' -f $plugin, $link); \
+	New-Item -ItemType SymbolicLink -Path $link -Target $plugin; \
+	\
+	Write-Host 'Verifying install ("docker-compose --version") ...'; \
+	docker-compose --version; \
+	\
+	Write-Host 'Complete.';

--- a/Dockerfile-windows-servercore.template
+++ b/Dockerfile-windows-servercore.template
@@ -32,3 +32,48 @@ RUN Write-Host ('Downloading {0} ...' -f $env:DOCKER_URL); \
 	docker --version; \
 	\
 	Write-Host 'Complete.';
+
+# https://github.com/docker-library/docker/issues/409#issuecomment-1462868414
+{{
+	{
+		buildx: .buildx,
+		compose: .compose,
+	}
+	| to_entries | map(
+		.key as $key | ($key | ascii_upcase) as $KEY | .value | (
+-}}
+ENV DOCKER_{{ $KEY }}_VERSION {{ .version }}
+ENV DOCKER_{{ $KEY }}_URL {{ .arches["windows-amd64"].url }}
+ENV DOCKER_{{ $KEY }}_SHA256 {{ .arches["windows-amd64"].sha256 }}
+RUN $dir = ('{0}\docker\cli-plugins' -f $env:ProgramFiles); \
+	Write-Host ('Creating {0} ...' -f $dir); \
+	New-Item -ItemType Directory $dir -Force; \
+	\
+	$plugin = ('{0}\docker-{{ $key }}.exe' -f $dir); \
+	Write-Host ('Downloading {0} ...' -f $env:DOCKER_{{ $KEY }}_URL); \
+	Invoke-WebRequest -Uri $env:DOCKER_{{ $KEY }}_URL -OutFile $plugin; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:DOCKER_{{ $KEY }}_SHA256); \
+	if ((Get-FileHash $plugin -Algorithm sha256).Hash -ne $env:DOCKER_{{ $KEY }}_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Verifying install ("docker {{ $key }} version") ...'; \
+	docker {{ $key }} version; \
+{{ if $key == "compose" then ( -}}
+	\
+	$link = ('{0}\docker\docker-{{ $key }}.exe' -f $env:ProgramFiles); \
+	Write-Host ('Linking {0} to {1} ...' -f $plugin, $link); \
+	New-Item -ItemType SymbolicLink -Path $link -Target $plugin; \
+	\
+	Write-Host 'Verifying install ("docker-{{ $key }} --version") ...'; \
+	docker-{{ $key }} --version; \
+{{ ) else "" end -}}
+	\
+	Write-Host 'Complete.';
+{{
+		)
+	)
+	| add
+-}}

--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -59,6 +59,8 @@ for version; do
 				;;
 		esac
 
+		echo "processing $dir ..."
+
 		mkdir -p "$dir"
 		{
 			generated_warning


### PR DESCRIPTION
Closes #409

Note however the sentiment from my comment at https://github.com/docker-library/docker/issues/409#issuecomment-1462868414: the Windows images here are _necessarily_ client-only (the daemon/engine _cannot_ currently run inside a container on Windows) _and_ BuildKit does not support Windows containers, so `docker buildx` here will _only_ be useful when connected to a remote Linux engine (or perhaps while using the "kubernetes" driver? again, connected to Linux)