### PR TITLE
Opt into buildkit-based builds

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -95,6 +95,7 @@ cat <<-EOH
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
+Builder: buildkit
 EOH
 
 # prints "$2$1$3$1...$N"
@@ -204,6 +205,9 @@ for version; do
 			GitCommit: $commit
 			Directory: $dir
 		EOE
-		[ "$variant" = "$v" ] || echo "Constraints: $variant"
+		if [ "$variant" != "$v" ]; then
+			echo "Constraints: $variant"
+			echo 'Builder: classic' # no Windows support in BuildKit (yet)
+		fi
 	done
 done


### PR DESCRIPTION
```diff
$ diff -u --color <(bashbrew cat docker) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2023-03-20 14:01:28.524558458 -0700
+++ /dev/fd/62	2023-03-20 14:01:28.516558392 -0700
@@ -1,5 +1,6 @@
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon), Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
+Builder: buildkit
 
 Tags: 23.0.1-cli, 23.0-cli, 23-cli, cli, 23.0.1-cli-alpine3.17
 Architectures: amd64, arm64v8
@@ -26,6 +27,7 @@
 Architectures: windows-amd64
 GitCommit: 1497727a0ec70e78a78563f365c76a21749ac27a
 Directory: 23.0/windows/windowsservercore-ltsc2022
+Builder: classic
 Constraints: windowsservercore-ltsc2022
 
 Tags: 23.0.1-windowsservercore-1809, 23.0-windowsservercore-1809, 23-windowsservercore-1809, windowsservercore-1809
@@ -33,6 +35,7 @@
 Architectures: windows-amd64
 GitCommit: 1497727a0ec70e78a78563f365c76a21749ac27a
 Directory: 23.0/windows/windowsservercore-1809
+Builder: classic
 Constraints: windowsservercore-1809
 
 Tags: 20.10.23-cli, 20.10-cli, 20-cli, 20.10.23-cli-alpine3.17, 20.10.23, 20.10, 20, 20.10.23-alpine3.17
@@ -60,6 +63,7 @@
 Architectures: windows-amd64
 GitCommit: 1497727a0ec70e78a78563f365c76a21749ac27a
 Directory: 20.10/windows/windowsservercore-ltsc2022
+Builder: classic
 Constraints: windowsservercore-ltsc2022
 
 Tags: 20.10.23-windowsservercore-1809, 20.10-windowsservercore-1809, 20-windowsservercore-1809
@@ -67,4 +71,5 @@
 Architectures: windows-amd64
 GitCommit: 1497727a0ec70e78a78563f365c76a21749ac27a
 Directory: 20.10/windows/windowsservercore-1809
+Builder: classic
 Constraints: windowsservercore-1809
```