### PR TITLE
Swap "git" variant to be "dind"-based in 23+

### DIFF
--- a/23.0/git/Dockerfile
+++ b/23.0/git/Dockerfile
@@ -4,6 +4,6 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM docker:23.0-cli
+FROM docker:23.0-dind
 
 RUN apk add --no-cache git

--- a/24-rc/git/Dockerfile
+++ b/24-rc/git/Dockerfile
@@ -4,6 +4,6 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM docker:24-rc-cli
+FROM docker:24-rc-dind
 
 RUN apk add --no-cache git

--- a/Dockerfile-git.template
+++ b/Dockerfile-git.template
@@ -1,3 +1,3 @@
-FROM docker:{{ env.version }}-cli
+FROM docker:{{ env.version }}-{{ if env.version | rtrimstr("-rc") == "20.10" then "cli" else "dind" end }}
 
 RUN apk add --no-cache git


### PR DESCRIPTION
Historically, `docker build git://...` would invoke `git` in the client context, but `buildx` does so in the daemon context instead, and given that it is the default in 23+, let's adjust the git-including variant to be dind-based to simplify this for users who desire the 50MiB+ increase this workflow requires.

Fixes #422
Closes #295