### PR TITLE
Load nf_tables in preparation of Alpine 3.19

### DIFF
--- a/23/dind/dockerd-entrypoint.sh
+++ b/23/dind/dockerd-entrypoint.sh
@@ -148,6 +148,7 @@ if [ "$1" = 'dockerd' ]; then
 		# https://github.com/docker-library/docker/issues/350
 		# https://github.com/moby/moby/issues/26824
 		modprobe ip_tables || :
+		modprobe nf_tables || :
 	fi
 
 	uid="$(id -u)"

--- a/24/dind/dockerd-entrypoint.sh
+++ b/24/dind/dockerd-entrypoint.sh
@@ -148,6 +148,7 @@ if [ "$1" = 'dockerd' ]; then
 		# https://github.com/docker-library/docker/issues/350
 		# https://github.com/moby/moby/issues/26824
 		modprobe ip_tables || :
+		modprobe nf_tables || :
 	fi
 
 	uid="$(id -u)"

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -148,6 +148,7 @@ if [ "$1" = 'dockerd' ]; then
 		# https://github.com/docker-library/docker/issues/350
 		# https://github.com/moby/moby/issues/26824
 		modprobe ip_tables || :
+		modprobe nf_tables || :
 	fi
 
 	uid="$(id -u)"


### PR DESCRIPTION
https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/47102 changes the default iptables backend to nf_tables. To prepare for the change (and to make sure it's not forgotten once DinD is updated), load nf_tables into the kernel.