### PR TITLE
Fix: USER (runAsNonRoot)

### DIFF
--- a/Dockerfile-dind-rootless.template
+++ b/Dockerfile-dind-rootless.template
@@ -43,4 +43,4 @@ RUN set -eux; \
 	mkdir -p /home/rootless/.local/share/docker; \
 	chown -R rootless:rootless /home/rootless/.local/share/docker
 VOLUME /home/rootless/.local/share/docker
-USER rootless
+USER 1000:1000


### PR DESCRIPTION
Supply the numeric uid/gid of the user/group created early in the Dockerfile. This is to ensure that (on k8s) runAsNonRoot works as expected because the username could indeed map to root (uid 0).

---

For context, I am using dind(-rootless) on a k8s cluster.