### PR TITLE
re-enable arm32v6 and arm32v7 builds

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -81,9 +81,6 @@ versionArches() {
 				.[env.version].arches | to_entries[]
 				| select(.value.'"$selector"')
 				| .key
-				# all arm32 builds are broken:
-				# https://github.com/docker-library/docker/issues/260
-				| select(startswith("arm32") | not)
 			' versions.json | sort
 		) \
 		<(xargs -n1 <<<"$parentArches" | sort)


### PR DESCRIPTION
- fixes https://github.com/docker-library/docker/issues/260
- fixes https://github.com/docker-library/docker/issues/325
- updates https://github.com/docker-library/docker/pull/326
- relates to https://github.com/moby/moby/issues/31254#issuecomment-1738675671

Builds for these architectures were broken for some time, but this should be resolved now, so we can re-enable these (fingers crossed).

This reverts commit 461a3ec6ed346995c5949cc2d70c08b9d049caa0.