### PR TITLE
Update to Alpine 3.19

### DIFF
--- a/24/cli/Dockerfile
+++ b/24/cli/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.18
+FROM alpine:3.19
 
 RUN apk add --no-cache \
 		ca-certificates \

--- a/24/dind/dockerd-entrypoint.sh
+++ b/24/dind/dockerd-entrypoint.sh
@@ -148,6 +148,7 @@ if [ "$1" = 'dockerd' ]; then
 		# https://github.com/docker-library/docker/issues/350
 		# https://github.com/moby/moby/issues/26824
 		modprobe ip_tables || :
+		modprobe nf_tables || :
 	fi
 
 	uid="$(id -u)"

--- a/24/dind/dockerd-entrypoint.sh
+++ b/24/dind/dockerd-entrypoint.sh
@@ -147,7 +147,7 @@ if [ "$1" = 'dockerd' ]; then
 		# if iptables fails to run, chances are high the necessary kernel modules aren't loaded (perhaps the host is using nftables with the translating "iptables" wrappers, for example)
 		# https://github.com/docker-library/docker/issues/350
 		# https://github.com/moby/moby/issues/26824
-		modprobe ip_tables || :
+		# https://github.com/docker-library/docker/pull/437#issuecomment-1854900620
 		modprobe nf_tables || :
 	fi
 

--- a/25-rc/cli/Dockerfile
+++ b/25-rc/cli/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.18
+FROM alpine:3.19
 
 RUN apk add --no-cache \
 		ca-certificates \

--- a/25-rc/dind/dockerd-entrypoint.sh
+++ b/25-rc/dind/dockerd-entrypoint.sh
@@ -148,6 +148,7 @@ if [ "$1" = 'dockerd' ]; then
 		# https://github.com/docker-library/docker/issues/350
 		# https://github.com/moby/moby/issues/26824
 		modprobe ip_tables || :
+		modprobe nf_tables || :
 	fi
 
 	uid="$(id -u)"

--- a/25-rc/dind/dockerd-entrypoint.sh
+++ b/25-rc/dind/dockerd-entrypoint.sh
@@ -147,7 +147,7 @@ if [ "$1" = 'dockerd' ]; then
 		# if iptables fails to run, chances are high the necessary kernel modules aren't loaded (perhaps the host is using nftables with the translating "iptables" wrappers, for example)
 		# https://github.com/docker-library/docker/issues/350
 		# https://github.com/moby/moby/issues/26824
-		modprobe ip_tables || :
+		# https://github.com/docker-library/docker/pull/437#issuecomment-1854900620
 		modprobe nf_tables || :
 	fi
 

--- a/Dockerfile-cli.template
+++ b/Dockerfile-cli.template
@@ -1,5 +1,5 @@
 {{ include "shared" -}}
-FROM alpine:3.18
+FROM alpine:3.19
 
 RUN apk add --no-cache \
 		ca-certificates \

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -148,6 +148,7 @@ if [ "$1" = 'dockerd' ]; then
 		# https://github.com/docker-library/docker/issues/350
 		# https://github.com/moby/moby/issues/26824
 		modprobe ip_tables || :
+		modprobe nf_tables || :
 	fi
 
 	uid="$(id -u)"

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -147,7 +147,7 @@ if [ "$1" = 'dockerd' ]; then
 		# if iptables fails to run, chances are high the necessary kernel modules aren't loaded (perhaps the host is using nftables with the translating "iptables" wrappers, for example)
 		# https://github.com/docker-library/docker/issues/350
 		# https://github.com/moby/moby/issues/26824
-		modprobe ip_tables || :
+		# https://github.com/docker-library/docker/pull/437#issuecomment-1854900620
 		modprobe nf_tables || :
 	fi
 


### PR DESCRIPTION
This updates Alpine to the latest stable version: 3.19.

See also https://alpinelinux.org/posts/Alpine-3.19.0-released.html.

*Edit: This is currently blocked as it requires additional upstream support for `nftables`; see also [comment below](https://github.com/docker-library/docker/pull/461#issuecomment-1845922045) and #437.*

Closes: https://github.com/docker-library/docker/pull/437