### PR TITLE
Switch over to xtables-legacy when nf_tables module isn't available

### DIFF
--- a/24/dind/Dockerfile
+++ b/24/dind/Dockerfile
@@ -14,9 +14,6 @@ RUN set -eux; \
 		e2fsprogs-extra \
 		ip6tables \
 		iptables \
-# dind might be used on systems where the nf_tables kernel module isn't available. In that case,
-# we need to switch over to xtables-legacy. See https://github.com/docker-library/docker/issues/463
-		iptables-legacy \
 		openssl \
 		shadow-uidmap \
 		xfsprogs \
@@ -32,6 +29,31 @@ RUN set -eux; \
 	fi
 
 # TODO aufs-tools
+
+# dind might be used on systems where the nf_tables kernel module isn't available. In that case,
+# we need to switch over to xtables-legacy. See https://github.com/docker-library/docker/issues/463
+RUN set -eux; \
+	apk add --no-cache iptables-legacy; \
+# set up a symlink farm we can use PATH to switch to legacy with
+	mkdir -p /usr/local/sbin/.iptables-legacy; \
+# https://git.alpinelinux.org/aports/tree/main/iptables/APKBUILD?id=b215d54de159eacafecb13c68dfadce6eefd9ec9#n73
+	for f in \
+		iptables \
+		iptables-save \
+		iptables-restore \
+		ip6tables \
+		ip6tables-save \
+		ip6tables-restore \
+	; do \
+# "iptables-save" -> "iptables-legacy-save", "ip6tables" -> "ip6tables-legacy", etc.
+# https://pkgs.alpinelinux.org/contents?branch=v3.19&name=iptables-legacy&arch=x86_64
+		b="/sbin/${f/tables/tables-legacy}"; \
+		"$b" --version; \
+		ln -svT "$b" "/usr/local/sbin/.iptables-legacy/$f"; \
+	done; \
+# verify it works (and gets us legacy)
+	export PATH="/usr/local/sbin/.iptables-legacy:$PATH"; \
+	iptables --version | grep legacy
 
 # set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
 RUN set -eux; \

--- a/24/dind/Dockerfile
+++ b/24/dind/Dockerfile
@@ -14,6 +14,9 @@ RUN set -eux; \
 		e2fsprogs-extra \
 		ip6tables \
 		iptables \
+# dind might be used on systems where the nf_tables kernel module isn't available. In that case,
+# we need to switch over to xtables-legacy. See https://github.com/docker-library/docker/issues/463
+		iptables-legacy \
 		openssl \
 		shadow-uidmap \
 		xfsprogs \

--- a/25-rc/dind/Dockerfile
+++ b/25-rc/dind/Dockerfile
@@ -14,9 +14,6 @@ RUN set -eux; \
 		e2fsprogs-extra \
 		ip6tables \
 		iptables \
-# dind might be used on systems where the nf_tables kernel module isn't available. In that case,
-# we need to switch over to xtables-legacy. See https://github.com/docker-library/docker/issues/463
-		iptables-legacy \
 		openssl \
 		shadow-uidmap \
 		xfsprogs \
@@ -32,6 +29,31 @@ RUN set -eux; \
 	fi
 
 # TODO aufs-tools
+
+# dind might be used on systems where the nf_tables kernel module isn't available. In that case,
+# we need to switch over to xtables-legacy. See https://github.com/docker-library/docker/issues/463
+RUN set -eux; \
+	apk add --no-cache iptables-legacy; \
+# set up a symlink farm we can use PATH to switch to legacy with
+	mkdir -p /usr/local/sbin/.iptables-legacy; \
+# https://git.alpinelinux.org/aports/tree/main/iptables/APKBUILD?id=b215d54de159eacafecb13c68dfadce6eefd9ec9#n73
+	for f in \
+		iptables \
+		iptables-save \
+		iptables-restore \
+		ip6tables \
+		ip6tables-save \
+		ip6tables-restore \
+	; do \
+# "iptables-save" -> "iptables-legacy-save", "ip6tables" -> "ip6tables-legacy", etc.
+# https://pkgs.alpinelinux.org/contents?branch=v3.19&name=iptables-legacy&arch=x86_64
+		b="/sbin/${f/tables/tables-legacy}"; \
+		"$b" --version; \
+		ln -svT "$b" "/usr/local/sbin/.iptables-legacy/$f"; \
+	done; \
+# verify it works (and gets us legacy)
+	export PATH="/usr/local/sbin/.iptables-legacy:$PATH"; \
+	iptables --version | grep legacy
 
 # set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
 RUN set -eux; \

--- a/25-rc/dind/Dockerfile
+++ b/25-rc/dind/Dockerfile
@@ -14,6 +14,9 @@ RUN set -eux; \
 		e2fsprogs-extra \
 		ip6tables \
 		iptables \
+# dind might be used on systems where the nf_tables kernel module isn't available. In that case,
+# we need to switch over to xtables-legacy. See https://github.com/docker-library/docker/issues/463
+		iptables-legacy \
 		openssl \
 		shadow-uidmap \
 		xfsprogs \

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -9,9 +9,6 @@ RUN set -eux; \
 		e2fsprogs-extra \
 		ip6tables \
 		iptables \
-# dind might be used on systems where the nf_tables kernel module isn't available. In that case,
-# we need to switch over to xtables-legacy. See https://github.com/docker-library/docker/issues/463
-		iptables-legacy \
 		openssl \
 		shadow-uidmap \
 		xfsprogs \
@@ -27,6 +24,31 @@ RUN set -eux; \
 	fi
 
 # TODO aufs-tools
+
+# dind might be used on systems where the nf_tables kernel module isn't available. In that case,
+# we need to switch over to xtables-legacy. See https://github.com/docker-library/docker/issues/463
+RUN set -eux; \
+	apk add --no-cache iptables-legacy; \
+# set up a symlink farm we can use PATH to switch to legacy with
+	mkdir -p /usr/local/sbin/.iptables-legacy; \
+# https://git.alpinelinux.org/aports/tree/main/iptables/APKBUILD?id=b215d54de159eacafecb13c68dfadce6eefd9ec9#n73
+	for f in \
+		iptables \
+		iptables-save \
+		iptables-restore \
+		ip6tables \
+		ip6tables-save \
+		ip6tables-restore \
+	; do \
+# "iptables-save" -> "iptables-legacy-save", "ip6tables" -> "ip6tables-legacy", etc.
+# https://pkgs.alpinelinux.org/contents?branch=v3.19&name=iptables-legacy&arch=x86_64
+		b="/sbin/${f/tables/tables-legacy}"; \
+		"$b" --version; \
+		ln -svT "$b" "/usr/local/sbin/.iptables-legacy/$f"; \
+	done; \
+# verify it works (and gets us legacy)
+	export PATH="/usr/local/sbin/.iptables-legacy:$PATH"; \
+	iptables --version | grep legacy
 
 # set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
 RUN set -eux; \

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -9,6 +9,9 @@ RUN set -eux; \
 		e2fsprogs-extra \
 		ip6tables \
 		iptables \
+# dind might be used on systems where the nf_tables kernel module isn't available. In that case,
+# we need to switch over to xtables-legacy. See https://github.com/docker-library/docker/issues/463
+		iptables-legacy \
 		openssl \
 		shadow-uidmap \
 		xfsprogs \


### PR DESCRIPTION
* Closes #461
* Closes #463
* Related to https://gitlab.com/gitlab-com/gl-infra/production/-/issues/17283

PR #461 updated Alpine to 3.19 and made a change to load the nf_tables kernel module if needed. However, as demonstrated by #463 and #464 this might break when the host system doesn't have the nf_tables module available. In that case, we should still try to load the ip_tables module and symlink /sbin/iptables to xtables-legacy-multi.