### PR TITLE
Ignore the exit code of `modprobe` always

### DIFF
--- a/24/dind/dockerd-entrypoint.sh
+++ b/24/dind/dockerd-entrypoint.sh
@@ -148,10 +148,14 @@ if [ "$1" = 'dockerd' ]; then
 		# https://github.com/docker-library/docker/issues/350
 		# https://github.com/moby/moby/issues/26824
 		# https://github.com/docker-library/docker/pull/437#issuecomment-1854900620
-		if ! modprobe nf_tables; then
+		modprobe nf_tables || :
+		if ! iptables -nL > /dev/null 2>&1; then
+			# might be host has no nf_tables, but Alpine is all-in now (so let's try a legacy fallback)
 			modprobe ip_tables || :
-			# see https://github.com/docker-library/docker/issues/463 (and the dind Dockerfile where this directory is set up)
-			export PATH="/usr/local/sbin/.iptables-legacy:$PATH"
+			if /usr/local/sbin/.iptables-legacy/iptables -nL > /dev/null 2>&1; then
+				# see https://github.com/docker-library/docker/issues/463 (and the dind Dockerfile where this directory is set up)
+				export PATH="/usr/local/sbin/.iptables-legacy:$PATH"
+			fi
 		fi
 	fi
 

--- a/24/dind/dockerd-entrypoint.sh
+++ b/24/dind/dockerd-entrypoint.sh
@@ -143,7 +143,20 @@ if [ "$1" = 'dockerd' ]; then
 	# XXX inject "docker-init" (tini) as pid1 to workaround https://github.com/docker-library/docker/issues/318 (zombie container-shim processes)
 	set -- docker-init -- "$@"
 
-	if ! iptables -nL > /dev/null 2>&1; then
+	iptablesLegacy=
+	if (
+		# https://git.netfilter.org/iptables/tree/iptables/nft-shared.c?id=f5cf76626d95d2c491a80288bccc160c53b44e88#n420
+		# https://github.com/docker-library/docker/pull/468#discussion_r1442131459
+		for f in /proc/net/ip_tables_names /proc/net/ip6_tables_names /proc/net/arp_tables_names; do
+			if b="$(cat "$f")" && [ -n "$b" ]; then
+				exit 0
+			fi
+		done
+		exit 1
+	); then
+		# if we already have any "legacy" iptables rules, we should always use legacy
+		iptablesLegacy=1
+	elif ! iptables -nL > /dev/null 2>&1; then
 		# if iptables fails to run, chances are high the necessary kernel modules aren't loaded (perhaps the host is using xtables, for example)
 		# https://github.com/docker-library/docker/issues/350
 		# https://github.com/moby/moby/issues/26824
@@ -153,10 +166,13 @@ if [ "$1" = 'dockerd' ]; then
 			# might be host has no nf_tables, but Alpine is all-in now (so let's try a legacy fallback)
 			modprobe ip_tables || :
 			if /usr/local/sbin/.iptables-legacy/iptables -nL > /dev/null 2>&1; then
-				# see https://github.com/docker-library/docker/issues/463 (and the dind Dockerfile where this directory is set up)
-				export PATH="/usr/local/sbin/.iptables-legacy:$PATH"
+				iptablesLegacy=1
 			fi
 		fi
+	fi
+	if [ -n "$iptablesLegacy" ]; then
+		# see https://github.com/docker-library/docker/issues/463 (and the dind Dockerfile where this directory is set up)
+		export PATH="/usr/local/sbin/.iptables-legacy:$PATH"
 	fi
 
 	uid="$(id -u)"

--- a/25-rc/dind/dockerd-entrypoint.sh
+++ b/25-rc/dind/dockerd-entrypoint.sh
@@ -148,10 +148,14 @@ if [ "$1" = 'dockerd' ]; then
 		# https://github.com/docker-library/docker/issues/350
 		# https://github.com/moby/moby/issues/26824
 		# https://github.com/docker-library/docker/pull/437#issuecomment-1854900620
-		if ! modprobe nf_tables; then
+		modprobe nf_tables || :
+		if ! iptables -nL > /dev/null 2>&1; then
+			# might be host has no nf_tables, but Alpine is all-in now (so let's try a legacy fallback)
 			modprobe ip_tables || :
-			# see https://github.com/docker-library/docker/issues/463 (and the dind Dockerfile where this directory is set up)
-			export PATH="/usr/local/sbin/.iptables-legacy:$PATH"
+			if /usr/local/sbin/.iptables-legacy/iptables -nL > /dev/null 2>&1; then
+				# see https://github.com/docker-library/docker/issues/463 (and the dind Dockerfile where this directory is set up)
+				export PATH="/usr/local/sbin/.iptables-legacy:$PATH"
+			fi
 		fi
 	fi
 

--- a/25-rc/dind/dockerd-entrypoint.sh
+++ b/25-rc/dind/dockerd-entrypoint.sh
@@ -143,7 +143,20 @@ if [ "$1" = 'dockerd' ]; then
 	# XXX inject "docker-init" (tini) as pid1 to workaround https://github.com/docker-library/docker/issues/318 (zombie container-shim processes)
 	set -- docker-init -- "$@"
 
-	if ! iptables -nL > /dev/null 2>&1; then
+	iptablesLegacy=
+	if (
+		# https://git.netfilter.org/iptables/tree/iptables/nft-shared.c?id=f5cf76626d95d2c491a80288bccc160c53b44e88#n420
+		# https://github.com/docker-library/docker/pull/468#discussion_r1442131459
+		for f in /proc/net/ip_tables_names /proc/net/ip6_tables_names /proc/net/arp_tables_names; do
+			if b="$(cat "$f")" && [ -n "$b" ]; then
+				exit 0
+			fi
+		done
+		exit 1
+	); then
+		# if we already have any "legacy" iptables rules, we should always use legacy
+		iptablesLegacy=1
+	elif ! iptables -nL > /dev/null 2>&1; then
 		# if iptables fails to run, chances are high the necessary kernel modules aren't loaded (perhaps the host is using xtables, for example)
 		# https://github.com/docker-library/docker/issues/350
 		# https://github.com/moby/moby/issues/26824
@@ -153,10 +166,13 @@ if [ "$1" = 'dockerd' ]; then
 			# might be host has no nf_tables, but Alpine is all-in now (so let's try a legacy fallback)
 			modprobe ip_tables || :
 			if /usr/local/sbin/.iptables-legacy/iptables -nL > /dev/null 2>&1; then
-				# see https://github.com/docker-library/docker/issues/463 (and the dind Dockerfile where this directory is set up)
-				export PATH="/usr/local/sbin/.iptables-legacy:$PATH"
+				iptablesLegacy=1
 			fi
 		fi
+	fi
+	if [ -n "$iptablesLegacy" ]; then
+		# see https://github.com/docker-library/docker/issues/463 (and the dind Dockerfile where this directory is set up)
+		export PATH="/usr/local/sbin/.iptables-legacy:$PATH"
 	fi
 
 	uid="$(id -u)"

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -148,10 +148,14 @@ if [ "$1" = 'dockerd' ]; then
 		# https://github.com/docker-library/docker/issues/350
 		# https://github.com/moby/moby/issues/26824
 		# https://github.com/docker-library/docker/pull/437#issuecomment-1854900620
-		if ! modprobe nf_tables; then
+		modprobe nf_tables || :
+		if ! iptables -nL > /dev/null 2>&1; then
+			# might be host has no nf_tables, but Alpine is all-in now (so let's try a legacy fallback)
 			modprobe ip_tables || :
-			# see https://github.com/docker-library/docker/issues/463 (and the dind Dockerfile where this directory is set up)
-			export PATH="/usr/local/sbin/.iptables-legacy:$PATH"
+			if /usr/local/sbin/.iptables-legacy/iptables -nL > /dev/null 2>&1; then
+				# see https://github.com/docker-library/docker/issues/463 (and the dind Dockerfile where this directory is set up)
+				export PATH="/usr/local/sbin/.iptables-legacy:$PATH"
+			fi
 		fi
 	fi
 

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -143,7 +143,20 @@ if [ "$1" = 'dockerd' ]; then
 	# XXX inject "docker-init" (tini) as pid1 to workaround https://github.com/docker-library/docker/issues/318 (zombie container-shim processes)
 	set -- docker-init -- "$@"
 
-	if ! iptables -nL > /dev/null 2>&1; then
+	iptablesLegacy=
+	if (
+		# https://git.netfilter.org/iptables/tree/iptables/nft-shared.c?id=f5cf76626d95d2c491a80288bccc160c53b44e88#n420
+		# https://github.com/docker-library/docker/pull/468#discussion_r1442131459
+		for f in /proc/net/ip_tables_names /proc/net/ip6_tables_names /proc/net/arp_tables_names; do
+			if b="$(cat "$f")" && [ -n "$b" ]; then
+				exit 0
+			fi
+		done
+		exit 1
+	); then
+		# if we already have any "legacy" iptables rules, we should always use legacy
+		iptablesLegacy=1
+	elif ! iptables -nL > /dev/null 2>&1; then
 		# if iptables fails to run, chances are high the necessary kernel modules aren't loaded (perhaps the host is using xtables, for example)
 		# https://github.com/docker-library/docker/issues/350
 		# https://github.com/moby/moby/issues/26824
@@ -153,10 +166,13 @@ if [ "$1" = 'dockerd' ]; then
 			# might be host has no nf_tables, but Alpine is all-in now (so let's try a legacy fallback)
 			modprobe ip_tables || :
 			if /usr/local/sbin/.iptables-legacy/iptables -nL > /dev/null 2>&1; then
-				# see https://github.com/docker-library/docker/issues/463 (and the dind Dockerfile where this directory is set up)
-				export PATH="/usr/local/sbin/.iptables-legacy:$PATH"
+				iptablesLegacy=1
 			fi
 		fi
+	fi
+	if [ -n "$iptablesLegacy" ]; then
+		# see https://github.com/docker-library/docker/issues/463 (and the dind Dockerfile where this directory is set up)
+		export PATH="/usr/local/sbin/.iptables-legacy:$PATH"
 	fi
 
 	uid="$(id -u)"


### PR DESCRIPTION
The nature of `modprobe` in this image is that it works via `ip` hacks, but the exit code will always be non-zero because we don't have `/lib/modules` from the host.

The effect of this was that everyone was using `iptables-legacy` (whether it was warranted for them to be doing so or not).

This probably fixes #466
This probably also fixes #467