### PR TITLE
Add a "docker" group (take two)

### DIFF
--- a/24/cli/Dockerfile
+++ b/24/cli/Dockerfile
@@ -17,6 +17,10 @@ RUN apk add --no-cache \
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN [ -e /etc/nsswitch.conf ] && grep '^hosts: files dns' /etc/nsswitch.conf
 
+# pre-add a "docker" group for socket usage
+RUN set -eux; \
+	addgroup -g 2375 -S docker
+
 ENV DOCKER_VERSION 24.0.7
 
 RUN set -eux; \

--- a/25-rc/cli/Dockerfile
+++ b/25-rc/cli/Dockerfile
@@ -17,6 +17,10 @@ RUN apk add --no-cache \
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN [ -e /etc/nsswitch.conf ] && grep '^hosts: files dns' /etc/nsswitch.conf
 
+# pre-add a "docker" group for socket usage
+RUN set -eux; \
+	addgroup -g 2375 -S docker
+
 ENV DOCKER_VERSION 25.0.0-beta.3
 
 RUN set -eux; \

--- a/Dockerfile-cli.template
+++ b/Dockerfile-cli.template
@@ -12,6 +12,10 @@ RUN apk add --no-cache \
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN [ -e /etc/nsswitch.conf ] && grep '^hosts: files dns' /etc/nsswitch.conf
 
+# pre-add a "docker" group for socket usage
+RUN set -eux; \
+	addgroup -g 2375 -S docker
+
 ENV DOCKER_VERSION {{ .version }}
 
 RUN set -eux; \


### PR DESCRIPTION
This reverts commit 3a0424834732f20142291cdd1d392e6d860af2ad (which reverted commit 9ebd7f6d5a3f26f47d627d0d7510f4b05fc9e977).

See #462 and https://github.com/docker-library/official-images/pull/15943, especially https://github.com/docker-library/official-images/pull/15943#issuecomment-1866962674