### PR TITLE
Switch to consuming JSON from GitHub for "latest commit"

### DIFF
--- a/versions.sh
+++ b/versions.sh
@@ -23,8 +23,10 @@ else
 fi
 versions=( "${versions[@]%/}" )
 
-dindLatest="$(curl -fsSL 'https://github.com/docker/docker/commits/master/hack/dind.atom' | grep -E 'id.*Commit')"
-dindLatest="$(awk <<<"$dindLatest" -F '[[:space:]]*[<>/]+' '$2 == "id" && $3 ~ /Commit/ { print $4; exit }')"
+dindLatest="$(
+	curl -fsSL -H 'Accept: application/json' 'https://github.com/docker/docker/commits/master/hack/dind.atom' \
+		| jq -r '.payload | first(.commitGroups[].commits[].oid)'
+)"
 
 dockerVersions="$(
 	git ls-remote --tags https://github.com/docker/docker.git \


### PR DESCRIPTION
For some reason, `curl -L https://github.com/docker/docker/commits/master/hack/dind.atom` has recently changed from returning XML by default to returning JSON, which from https://docs.github.com/en/rest/activity/feeds?apiVersion=2022-11-28 seems like it's intentional, so this adds an explicit `Accept:` header (the only explicit JSON one that seems to work) and uses `jq` to determine the latest `hack/dind` commit instead of hacking up the XML via `grep`+`awk`.