### PR TITLE
Add `git` to `dind` variants (and make `git` an alias of `dind`, for 24.x and 25.x)

### DIFF
--- a/24/dind/Dockerfile
+++ b/24/dind/Dockerfile
@@ -6,29 +6,23 @@
 
 FROM docker:24-cli
 
-# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
+# https://github.com/moby/moby/blob/0eecd59153c03ced5f5ddd79cc98f29e4d86daec/project/PACKAGERS.md#runtime-dependencies
+# https://github.com/docker/docker-ce-packaging/blob/963aa02666035d4e268f33c63d7868d6cdd1d34c/deb/common/control#L28-L41
 RUN set -eux; \
 	apk add --no-cache \
 		btrfs-progs \
 		e2fsprogs \
 		e2fsprogs-extra \
+		git \
 		ip6tables \
 		iptables \
 		openssl \
+		pigz \
 		shadow-uidmap \
 		xfsprogs \
 		xz \
-# pigz: https://github.com/moby/moby/pull/35697 (faster gzip implementation)
-		pigz \
-	; \
-# only install zfs if it's available for the current architecture
-# https://git.alpinelinux.org/cgit/aports/tree/main/zfs/APKBUILD?h=3.6-stable#n9 ("all !armhf !ppc64le" as of 2017-11-01)
-# "apk info XYZ" exits with a zero exit code but no output when the package exists but not for this arch
-	if zfs="$(apk info --no-cache --quiet zfs)" && [ -n "$zfs" ]; then \
-		apk add --no-cache zfs; \
-	fi
-
-# TODO aufs-tools
+		zfs \
+	;
 
 # dind might be used on systems where the nf_tables kernel module isn't available. In that case,
 # we need to switch over to xtables-legacy. See https://github.com/docker-library/docker/issues/463

--- a/24/git/Dockerfile
+++ b/24/git/Dockerfile
@@ -1,9 +1,0 @@
-#
-# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
-#
-# PLEASE DO NOT EDIT IT DIRECTLY.
-#
-
-FROM docker:24-dind
-
-RUN apk add --no-cache git

--- a/25/dind/Dockerfile
+++ b/25/dind/Dockerfile
@@ -6,29 +6,23 @@
 
 FROM docker:25-cli
 
-# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
+# https://github.com/moby/moby/blob/0eecd59153c03ced5f5ddd79cc98f29e4d86daec/project/PACKAGERS.md#runtime-dependencies
+# https://github.com/docker/docker-ce-packaging/blob/963aa02666035d4e268f33c63d7868d6cdd1d34c/deb/common/control#L28-L41
 RUN set -eux; \
 	apk add --no-cache \
 		btrfs-progs \
 		e2fsprogs \
 		e2fsprogs-extra \
+		git \
 		ip6tables \
 		iptables \
 		openssl \
+		pigz \
 		shadow-uidmap \
 		xfsprogs \
 		xz \
-# pigz: https://github.com/moby/moby/pull/35697 (faster gzip implementation)
-		pigz \
-	; \
-# only install zfs if it's available for the current architecture
-# https://git.alpinelinux.org/cgit/aports/tree/main/zfs/APKBUILD?h=3.6-stable#n9 ("all !armhf !ppc64le" as of 2017-11-01)
-# "apk info XYZ" exits with a zero exit code but no output when the package exists but not for this arch
-	if zfs="$(apk info --no-cache --quiet zfs)" && [ -n "$zfs" ]; then \
-		apk add --no-cache zfs; \
-	fi
-
-# TODO aufs-tools
+		zfs \
+	;
 
 # dind might be used on systems where the nf_tables kernel module isn't available. In that case,
 # we need to switch over to xtables-legacy. See https://github.com/docker-library/docker/issues/463

--- a/25/git/Dockerfile
+++ b/25/git/Dockerfile
@@ -1,9 +1,0 @@
-#
-# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
-#
-# PLEASE DO NOT EDIT IT DIRECTLY.
-#
-
-FROM docker:25-dind
-
-RUN apk add --no-cache git

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -1,29 +1,23 @@
 {{ include "shared" -}}
 FROM docker:{{ env.version }}-cli
 
-# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
+# https://github.com/moby/moby/blob/0eecd59153c03ced5f5ddd79cc98f29e4d86daec/project/PACKAGERS.md#runtime-dependencies
+# https://github.com/docker/docker-ce-packaging/blob/963aa02666035d4e268f33c63d7868d6cdd1d34c/deb/common/control#L28-L41
 RUN set -eux; \
 	apk add --no-cache \
 		btrfs-progs \
 		e2fsprogs \
 		e2fsprogs-extra \
+		git \
 		ip6tables \
 		iptables \
 		openssl \
+		pigz \
 		shadow-uidmap \
 		xfsprogs \
 		xz \
-# pigz: https://github.com/moby/moby/pull/35697 (faster gzip implementation)
-		pigz \
-	; \
-# only install zfs if it's available for the current architecture
-# https://git.alpinelinux.org/cgit/aports/tree/main/zfs/APKBUILD?h=3.6-stable#n9 ("all !armhf !ppc64le" as of 2017-11-01)
-# "apk info XYZ" exits with a zero exit code but no output when the package exists but not for this arch
-	if zfs="$(apk info --no-cache --quiet zfs)" && [ -n "$zfs" ]; then \
-		apk add --no-cache zfs; \
-	fi
-
-# TODO aufs-tools
+		zfs \
+	;
 
 # dind might be used on systems where the nf_tables kernel module isn't available. In that case,
 # we need to switch over to xtables-legacy. See https://github.com/docker-library/docker/issues/463

--- a/Dockerfile-git.template
+++ b/Dockerfile-git.template
@@ -1,3 +1,0 @@
-FROM docker:{{ env.version }}-dind
-
-RUN apk add --no-cache git

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -77,9 +77,9 @@ versionArches() {
 
 	comm -12 \
 		<(
-			version="$version" jq -r '
+			version="$version" jq -r --arg selector "$selector" '
 				.[env.version].arches | to_entries[]
-				| select(.value.'"$selector"')
+				| select(.value[$selector])
 				| .key
 			' versions.json | sort
 		) \
@@ -175,6 +175,12 @@ for version; do
 			suiteAliases=( "${suiteAliases[@]//latest-/}" )
 			variantAliases+=( "${suiteAliases[@]}" )
 			if [ "$variant" = 'dind' ]; then
+				# add "git" aliases https://github.com/docker-library/docker/issues/482#issuecomment-1955609423
+				if [ "$version" = '24' ] || [ "$version" = '25' ]; then
+					gitAliases=( "${versionAliases[@]/%/-git}" )
+					gitAliases=( "${gitAliases[@]//latest-/}" )
+					variantAliases+=( "${gitAliases[@]}" )
+				fi
 				# add "latest" aliases
 				suiteAliases=( "${versionAliases[0]}" ) # only "X.Y.Z-foo"
 				suiteAliases=( "${suiteAliases[@]/%/-alpine$alpine}" )

--- a/versions.json
+++ b/versions.json
@@ -134,7 +134,6 @@
       "cli",
       "dind",
       "dind-rootless",
-      "git",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809"
     ],
@@ -276,7 +275,6 @@
       "cli",
       "dind",
       "dind-rootless",
-      "git",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809"
     ],

--- a/versions.sh
+++ b/versions.sh
@@ -267,7 +267,6 @@ for version in "${versions[@]}"; do
 		cli \
 		dind \
 		dind-rootless \
-		git \
 		windows/windowsservercore-ltsc2022 \
 		windows/windowsservercore-1809 \
 	; do


### PR DESCRIPTION
See https://github.com/docker-library/docker/issues/482#issuecomment-1955609423
Closes #482

(with [apologies](https://github.com/docker-library/docker/pull/295) to @thaJeztah :heart:)

This also does some minor cleanup of our installation of other dependencies.