### PR TITLE
Update to Alpine 3.20

### DIFF
--- a/24/cli/Dockerfile
+++ b/24/cli/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 RUN apk add --no-cache \
 		ca-certificates \

--- a/25/cli/Dockerfile
+++ b/25/cli/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 RUN apk add --no-cache \
 		ca-certificates \

--- a/26/cli/Dockerfile
+++ b/26/cli/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 RUN apk add --no-cache \
 		ca-certificates \

--- a/Dockerfile-cli.template
+++ b/Dockerfile-cli.template
@@ -1,5 +1,5 @@
 {{ include "shared" -}}
-FROM alpine:3.19
+FROM alpine:3.20
 
 RUN apk add --no-cache \
 		ca-certificates \


### PR DESCRIPTION
This updates Alpine to the latest stable version: 3.20.

Requires https://github.com/docker-library/official-images/pull/16801.

See also https://alpinelinux.org/posts/Alpine-3.20.0-released.html.

Modelled after #461 (albeit hopefully less 'impactful' this time 😓)