### PR TITLE
Also load `ip6_tables` when trying to load `ip_tables`

### DIFF
--- a/24/dind/dockerd-entrypoint.sh
+++ b/24/dind/dockerd-entrypoint.sh
@@ -149,6 +149,7 @@ if [ "$1" = 'dockerd' ]; then
 		iptablesLegacy="$DOCKER_IPTABLES_LEGACY"
 		if [ -n "$iptablesLegacy" ]; then
 			modprobe ip_tables || :
+			modprobe ip6_tables || :
 		else
 			modprobe nf_tables || :
 		fi
@@ -173,6 +174,7 @@ if [ "$1" = 'dockerd' ]; then
 		if ! iptables -nL > /dev/null 2>&1; then
 			# might be host has no nf_tables, but Alpine is all-in now (so let's try a legacy fallback)
 			modprobe ip_tables || :
+			modprobe ip6_tables || :
 			if /usr/local/sbin/.iptables-legacy/iptables -nL > /dev/null 2>&1; then
 				iptablesLegacy=1
 			fi

--- a/25/dind/dockerd-entrypoint.sh
+++ b/25/dind/dockerd-entrypoint.sh
@@ -149,6 +149,7 @@ if [ "$1" = 'dockerd' ]; then
 		iptablesLegacy="$DOCKER_IPTABLES_LEGACY"
 		if [ -n "$iptablesLegacy" ]; then
 			modprobe ip_tables || :
+			modprobe ip6_tables || :
 		else
 			modprobe nf_tables || :
 		fi
@@ -173,6 +174,7 @@ if [ "$1" = 'dockerd' ]; then
 		if ! iptables -nL > /dev/null 2>&1; then
 			# might be host has no nf_tables, but Alpine is all-in now (so let's try a legacy fallback)
 			modprobe ip_tables || :
+			modprobe ip6_tables || :
 			if /usr/local/sbin/.iptables-legacy/iptables -nL > /dev/null 2>&1; then
 				iptablesLegacy=1
 			fi

--- a/26/dind/dockerd-entrypoint.sh
+++ b/26/dind/dockerd-entrypoint.sh
@@ -149,6 +149,7 @@ if [ "$1" = 'dockerd' ]; then
 		iptablesLegacy="$DOCKER_IPTABLES_LEGACY"
 		if [ -n "$iptablesLegacy" ]; then
 			modprobe ip_tables || :
+			modprobe ip6_tables || :
 		else
 			modprobe nf_tables || :
 		fi
@@ -173,6 +174,7 @@ if [ "$1" = 'dockerd' ]; then
 		if ! iptables -nL > /dev/null 2>&1; then
 			# might be host has no nf_tables, but Alpine is all-in now (so let's try a legacy fallback)
 			modprobe ip_tables || :
+			modprobe ip6_tables || :
 			if /usr/local/sbin/.iptables-legacy/iptables -nL > /dev/null 2>&1; then
 				iptablesLegacy=1
 			fi

--- a/27-rc/dind/dockerd-entrypoint.sh
+++ b/27-rc/dind/dockerd-entrypoint.sh
@@ -149,6 +149,7 @@ if [ "$1" = 'dockerd' ]; then
 		iptablesLegacy="$DOCKER_IPTABLES_LEGACY"
 		if [ -n "$iptablesLegacy" ]; then
 			modprobe ip_tables || :
+			modprobe ip6_tables || :
 		else
 			modprobe nf_tables || :
 		fi
@@ -173,6 +174,7 @@ if [ "$1" = 'dockerd' ]; then
 		if ! iptables -nL > /dev/null 2>&1; then
 			# might be host has no nf_tables, but Alpine is all-in now (so let's try a legacy fallback)
 			modprobe ip_tables || :
+			modprobe ip6_tables || :
 			if /usr/local/sbin/.iptables-legacy/iptables -nL > /dev/null 2>&1; then
 				iptablesLegacy=1
 			fi

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -149,6 +149,7 @@ if [ "$1" = 'dockerd' ]; then
 		iptablesLegacy="$DOCKER_IPTABLES_LEGACY"
 		if [ -n "$iptablesLegacy" ]; then
 			modprobe ip_tables || :
+			modprobe ip6_tables || :
 		else
 			modprobe nf_tables || :
 		fi
@@ -173,6 +174,7 @@ if [ "$1" = 'dockerd' ]; then
 		if ! iptables -nL > /dev/null 2>&1; then
 			# might be host has no nf_tables, but Alpine is all-in now (so let's try a legacy fallback)
 			modprobe ip_tables || :
+			modprobe ip6_tables || :
 			if /usr/local/sbin/.iptables-legacy/iptables -nL > /dev/null 2>&1; then
 				iptablesLegacy=1
 			fi


### PR DESCRIPTION
This isn't used/necessary in the default configuration until Docker 27+, but it was optional behavior before that, so it's prudent for us to also try loading it any time we know we're not using nftables / have explicitly requested "legacy" `iptables`.

See also:
- https://github.com/moby/moby/pull/47747
- https://github.com/moby/moby/issues/47895
- https://github.com/moby/moby/pull/47918
- https://github.com/moby/moby/pull/47960

cc/fyi @robmry @akerouanton :heart: