### PR TITLE
Add `git` to CLI variants

### DIFF
--- a/24/cli/Dockerfile
+++ b/24/cli/Dockerfile
@@ -9,7 +9,9 @@ FROM alpine:3.20
 RUN apk add --no-cache \
 		ca-certificates \
 # DOCKER_HOST=ssh://... -- https://github.com/docker/cli/pull/1014
-		openssh-client
+		openssh-client \
+# https://github.com/docker-library/docker/issues/482#issuecomment-2197116408
+		git
 
 # ensure that nsswitch.conf is set up for Go's "netgo" implementation (which Docker explicitly uses)
 # - https://github.com/moby/moby/blob/v24.0.6/hack/make.sh#L111

--- a/25/cli/Dockerfile
+++ b/25/cli/Dockerfile
@@ -9,7 +9,9 @@ FROM alpine:3.20
 RUN apk add --no-cache \
 		ca-certificates \
 # DOCKER_HOST=ssh://... -- https://github.com/docker/cli/pull/1014
-		openssh-client
+		openssh-client \
+# https://github.com/docker-library/docker/issues/482#issuecomment-2197116408
+		git
 
 # ensure that nsswitch.conf is set up for Go's "netgo" implementation (which Docker explicitly uses)
 # - https://github.com/moby/moby/blob/v24.0.6/hack/make.sh#L111

--- a/26/cli/Dockerfile
+++ b/26/cli/Dockerfile
@@ -9,7 +9,9 @@ FROM alpine:3.20
 RUN apk add --no-cache \
 		ca-certificates \
 # DOCKER_HOST=ssh://... -- https://github.com/docker/cli/pull/1014
-		openssh-client
+		openssh-client \
+# https://github.com/docker-library/docker/issues/482#issuecomment-2197116408
+		git
 
 # ensure that nsswitch.conf is set up for Go's "netgo" implementation (which Docker explicitly uses)
 # - https://github.com/moby/moby/blob/v24.0.6/hack/make.sh#L111

--- a/27/cli/Dockerfile
+++ b/27/cli/Dockerfile
@@ -9,7 +9,9 @@ FROM alpine:3.20
 RUN apk add --no-cache \
 		ca-certificates \
 # DOCKER_HOST=ssh://... -- https://github.com/docker/cli/pull/1014
-		openssh-client
+		openssh-client \
+# https://github.com/docker-library/docker/issues/482#issuecomment-2197116408
+		git
 
 # ensure that nsswitch.conf is set up for Go's "netgo" implementation (which Docker explicitly uses)
 # - https://github.com/moby/moby/blob/v24.0.6/hack/make.sh#L111

--- a/Dockerfile-cli.template
+++ b/Dockerfile-cli.template
@@ -4,7 +4,9 @@ FROM alpine:3.20
 RUN apk add --no-cache \
 		ca-certificates \
 # DOCKER_HOST=ssh://... -- https://github.com/docker/cli/pull/1014
-		openssh-client
+		openssh-client \
+# https://github.com/docker-library/docker/issues/482#issuecomment-2197116408
+		git
 
 # ensure that nsswitch.conf is set up for Go's "netgo" implementation (which Docker explicitly uses)
 # - https://github.com/moby/moby/blob/v24.0.6/hack/make.sh#L111


### PR DESCRIPTION
- `docker build .` / `docker buildx build .` might shell out to git to ask about the context directory's `git status`
- `DOCKER_BUILDKIT=0 docker build https://example/foo.git` will run git in the client context
- `docker buildx build https://example/foo.git` will run git in the daemon context

https://github.com/docker-library/docker/issues/482#issuecomment-2197116408