### PR TITLE
Fix failing `versions.sh` that is causing the update job to fail

### DIFF
--- a/versions.sh
+++ b/versions.sh
@@ -103,7 +103,7 @@ for buildxVersion in $buildxVersions; do
 				| select(.file | test("[.]json$") | not)
 				| { (
 					.file
-					| capture("[.](?<os>linux|windows|darwin)-(?<arch>[^.]+)(?<ext>[.]exe)?$")
+					| capture("[.](?<os>linux|windows|darwin|freebsd|openbsd)-(?<arch>[^.]+)(?<ext>[.]exe)?$")
 					// error("failed to parse os-arch from filename: " + .)
 					| if .os == "linux" then "" else .os + "-" end
 					+ ({


### PR DESCRIPTION
Adjust jq regex to account for BSD artifacts

Before the fix:
```console
jq: error (at <stdin>:39): failed to parse os-arch from filename: buildx-v0.19.1.freebsd-amd64
```

After the fix:
```console
$ ./versions.sh
27: 27.3.1 (buildx 0.19.1, compose 2.31.0)
27-rc: 27.4.0-rc.3 (buildx 0.19.1, compose 2.31.0)
```