### PR TITLE
Add Windows Server 2025 variant

### DIFF
--- a/27/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/27/windows/windowsservercore-ltsc2025/Dockerfile
@@ -1,0 +1,91 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2025
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\docker;{1}' -f $env:ProgramFiles, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV DOCKER_VERSION 27.5.0
+ENV DOCKER_URL https://download.docker.com/win/static/stable/x86_64/docker-27.5.0.zip
+# TODO ENV DOCKER_SHA256
+# https://github.com/docker/docker-ce/blob/5b073ee2cf564edee5adca05eee574142f7627bb/components/packaging/static/hash_files !!
+# (no SHA file artifacts on download.docker.com yet as of 2017-06-07 though)
+
+RUN Write-Host ('Downloading {0} ...' -f $env:DOCKER_URL); \
+	Invoke-WebRequest -Uri $env:DOCKER_URL -OutFile 'docker.zip'; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive docker.zip -DestinationPath $env:ProgramFiles; \
+# (this archive has a "docker/..." directory in it already)
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item @( \
+			'docker.zip', \
+			('{0}\docker\dockerd.exe' -f $env:ProgramFiles) \
+		) -Force; \
+	\
+	Write-Host 'Verifying install ("docker --version") ...'; \
+	docker --version; \
+	\
+	Write-Host 'Complete.';
+
+# https://github.com/docker-library/docker/issues/409#issuecomment-1462868414
+ENV DOCKER_BUILDX_VERSION 0.20.0
+ENV DOCKER_BUILDX_URL https://github.com/docker/buildx/releases/download/v0.20.0/buildx-v0.20.0.windows-amd64.exe
+ENV DOCKER_BUILDX_SHA256 61123c807345d35525bc242bb182526cb0c10310eaf107bbcc97695be528c141
+RUN $dir = ('{0}\docker\cli-plugins' -f $env:ProgramFiles); \
+	Write-Host ('Creating {0} ...' -f $dir); \
+	New-Item -ItemType Directory $dir -Force; \
+	\
+	$plugin = ('{0}\docker-buildx.exe' -f $dir); \
+	Write-Host ('Downloading {0} ...' -f $env:DOCKER_BUILDX_URL); \
+	Invoke-WebRequest -Uri $env:DOCKER_BUILDX_URL -OutFile $plugin; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:DOCKER_BUILDX_SHA256); \
+	if ((Get-FileHash $plugin -Algorithm sha256).Hash -ne $env:DOCKER_BUILDX_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Verifying install ("docker buildx version") ...'; \
+	docker buildx version; \
+	\
+	Write-Host 'Complete.';
+ENV DOCKER_COMPOSE_VERSION 2.32.4
+ENV DOCKER_COMPOSE_URL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-windows-x86_64.exe
+ENV DOCKER_COMPOSE_SHA256 5df58bb738c7ac2712c031e15154b49f32f4026640d8c0539090d6e0a66d6dfd
+RUN $dir = ('{0}\docker\cli-plugins' -f $env:ProgramFiles); \
+	Write-Host ('Creating {0} ...' -f $dir); \
+	New-Item -ItemType Directory $dir -Force; \
+	\
+	$plugin = ('{0}\docker-compose.exe' -f $dir); \
+	Write-Host ('Downloading {0} ...' -f $env:DOCKER_COMPOSE_URL); \
+	Invoke-WebRequest -Uri $env:DOCKER_COMPOSE_URL -OutFile $plugin; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:DOCKER_COMPOSE_SHA256); \
+	if ((Get-FileHash $plugin -Algorithm sha256).Hash -ne $env:DOCKER_COMPOSE_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Verifying install ("docker compose version") ...'; \
+	docker compose version; \
+	\
+	$link = ('{0}\docker\docker-compose.exe' -f $env:ProgramFiles); \
+	Write-Host ('Linking {0} to {1} ...' -f $plugin, $link); \
+	New-Item -ItemType SymbolicLink -Path $link -Target $plugin; \
+	\
+	Write-Host 'Verifying install ("docker-compose --version") ...'; \
+	docker-compose --version; \
+	\
+	Write-Host 'Complete.';

--- a/versions.json
+++ b/versions.json
@@ -154,6 +154,7 @@
       "cli",
       "dind",
       "dind-rootless",
+      "windows/windowsservercore-ltsc2025",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809"
     ],

--- a/versions.sh
+++ b/versions.sh
@@ -282,6 +282,7 @@ for version in "${versions[@]}"; do
 		cli \
 		dind \
 		dind-rootless \
+		windows/windowsservercore-ltsc2025 \
 		windows/windowsservercore-ltsc2022 \
 		windows/windowsservercore-1809 \
 	; do


### PR DESCRIPTION
Add Windows Server ltsc2025; keep 1809 as it is still in extended support (we may drop it later, even while it is supported by Windows).

Refs: https://github.com/docker-library/official-images/pull/18143