### PR TITLE
Adjust jq regex to account for (more) BSD artifacts

### DIFF
--- a/versions.sh
+++ b/versions.sh
@@ -103,7 +103,7 @@ for buildxVersion in $buildxVersions; do
 				| select(.file | test("[.]json$") | not)
 				| { (
 					.file
-					| capture("[.](?<os>linux|windows|darwin|freebsd|openbsd)-(?<arch>[^.]+)(?<ext>[.]exe)?$")
+					| capture("[.](?<os>linux|windows|darwin|[a-z0-9]*bsd)-(?<arch>[^.]+)(?<ext>[.]exe)?$")
 					// error("failed to parse os-arch from filename: " + .)
 					| if .os == "linux" then "" else .os + "-" end
 					+ ({


### PR DESCRIPTION
Basically, the same as https://github.com/docker-library/docker/pull/516, but now there are `netbsd` artifacts to account for so I made the regex more generic to match any `bsd`.