### PR TITLE
Add additional extensions to generated ssl certs

### DIFF
--- a/28/dind/dockerd-entrypoint.sh
+++ b/28/dind/dockerd-entrypoint.sh
@@ -53,6 +53,7 @@ _tls_generate_certs() {
 			-subj '/CN=docker:dind server'
 		cat > "$dir/server/openssl.cnf" <<-EOF
 			[ x509_exts ]
+			extendedKeyUsage = serverAuth
 			subjectAltName = $(_tls_san)
 		EOF
 		openssl x509 -req \

--- a/28/dind/dockerd-entrypoint.sh
+++ b/28/dind/dockerd-entrypoint.sh
@@ -41,7 +41,10 @@ _tls_generate_certs() {
 		_tls_ensure_private "$dir/ca/key.pem"
 		openssl req -new -key "$dir/ca/key.pem" \
 			-out "$dir/ca/cert.pem" \
-			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
+			-subj '/CN=docker:dind CA' \
+			-x509 \
+			-days "$certValidDays" \
+			-addext keyUsage=critical,digitalSignature,keyCertSign
 	fi
 
 	if [ -s "$dir/ca/key.pem" ]; then

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -53,6 +53,7 @@ _tls_generate_certs() {
 			-subj '/CN=docker:dind server'
 		cat > "$dir/server/openssl.cnf" <<-EOF
 			[ x509_exts ]
+			extendedKeyUsage = serverAuth
 			subjectAltName = $(_tls_san)
 		EOF
 		openssl x509 -req \

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -41,7 +41,10 @@ _tls_generate_certs() {
 		_tls_ensure_private "$dir/ca/key.pem"
 		openssl req -new -key "$dir/ca/key.pem" \
 			-out "$dir/ca/cert.pem" \
-			-subj '/CN=docker:dind CA' -x509 -days "$certValidDays"
+			-subj '/CN=docker:dind CA' \
+			-x509 \
+			-days "$certValidDays" \
+			-addext keyUsage=critical,digitalSignature,keyCertSign
 	fi
 
 	if [ -s "$dir/ca/key.pem" ]; then


### PR DESCRIPTION
This MR adds some additional extensions to the self-generated CA and server certificates the dind image may employ to set up TLS connections. This ensures the certificates (better) match RFCs specifying these extensions as required (see https://datatracker.ietf.org/doc/html/rfc3280 and https://datatracker.ietf.org/doc/html/rfc5280). This is particularly relevant for clients enforcing checks on this while connecting.

## Source of the problem

When using my combination of:
- GitLab CI 
- Docker dind image as service in CI job
- Python Docker image employing the [Docker SDK for Python](https://docker-py.readthedocs.io/en/stable/) to connect to the Docker daemon

I was presented with errors among the following lines:
> docker.errors.DockerException: Error while fetching server API version: HTTPSConnectionPool(host='docker', port=2376): Max retries exceeded with url: /version (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: CA cert does not include key usage extension (_ssl.c:1028)')))

This is due to a [recent change](https://github.com/urllib3/urllib3/issues/3571) in the Python `urllib3` package used by the Python Docker SDK, which follows the [stricter checks Python introduced with >=3.13](https://github.com/python/cpython/pull/112389). 

## MWE + proof of fix

I've created https://gitlab.com/jnoordsij/test-docker-ci/-/tree/e5289dcdc5a736663d66ea4199f95f5c94d73fec as basic example of attempting to use the Python Docker SDK with the dind image that fails; see https://gitlab.com/jnoordsij/test-docker-ci/-/jobs/10076832026.

After building a patched dind image (https://gitlab.com/jnoordsij/test-docker-ci/-/commit/0c6a1ac70fd6d6f26e29af8d5d797b3d70d41967) and using that in the CI job, everything seems to work fine
(see also https://gitlab.com/jnoordsij/test-docker-ci/-/pipelines/1824971402).

## Further notes

I think technically speaking only the second commit, updating the CA cert, is required to fix this particular issue. However when looking into this, I figured adding the server cert extensions is probably good practice, especially with this being recommended in official documentation.