### PR TITLE
Add Alpine package slirp4netns to dind-rootless

### DIFF
--- a/28/dind-rootless/Dockerfile
+++ b/28/dind-rootless/Dockerfile
@@ -8,7 +8,8 @@ FROM docker:28-dind
 
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1
-RUN apk add --no-cache iproute2 fuse-overlayfs
+# slirp4netns can be selected as rootlesskit's net driver using "-e DOCKERD_ROOTLESS_ROOTLESSKIT_NET=slirp4netns"
+RUN apk add --no-cache iproute2 fuse-overlayfs slirp4netns
 
 # "/run/user/UID" will be used by default as the value of XDG_RUNTIME_DIR
 RUN mkdir /run/user && chmod 1777 /run/user

--- a/Dockerfile-dind-rootless.template
+++ b/Dockerfile-dind-rootless.template
@@ -3,7 +3,8 @@ FROM docker:{{ env.version }}-dind
 
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1
-RUN apk add --no-cache iproute2 fuse-overlayfs
+# slirp4netns can be selected as rootlesskit's net driver using "-e DOCKERD_ROOTLESS_ROOTLESSKIT_NET=slirp4netns"
+RUN apk add --no-cache iproute2 fuse-overlayfs slirp4netns
 
 # "/run/user/UID" will be used by default as the value of XDG_RUNTIME_DIR
 RUN mkdir /run/user && chmod 1777 /run/user


### PR DESCRIPTION
- workaround for https://github.com/moby/moby/issues/47628
- related to https://github.com/docker-library/docker/pull/274

The default net driver for rootlesskit in dind-rootless is vpnkit - this change adds slirp4netns as an alternative.

The [default](https://docs.docker.com/engine/security/rootless/#networking-errors) and [recommended](https://github.com/rootless-containers/rootlesskit/blob/master/docs/network.md#--netslirp4netns-recommended) network driver for rootlesskit is slirp4netns.

Using slirp4netns instead of vpnkit works-around https://github.com/moby/moby/issues/47628, which reports that ...
> If the upstream DNS server strips out IPv6 addresses, DNS lookups inside containers started in dind-rootless fail with NXDOMAIN even though the response seems to contain a valid IP addresses.

The [original PR](https://github.com/docker-library/docker/pull/274) wasn't merged, >4 years ago, because of concerns about CVEs in slirp4netns (long since resolved), and its GPLv2 license (but now it's available as an Alpine package, like any other - including `iproute2`, which is already installed here).

This PR only adds the package - vpnkit is still the default. To use slirp4netns, the `dind-rootless` container must be started with "-e DOCKERD_ROOTLESS_ROOTLESSKIT_NET=slirp4netns" will override the default.

_We could perhaps made slirp4netns the default net driver, at-least for moby 29? Any thoughts? cc @AkihiroSuda._