### PR TITLE
Use UID number rather than username in Dockerfile

### DIFF
--- a/28/dind-rootless/Dockerfile
+++ b/28/dind-rootless/Dockerfile
@@ -52,4 +52,4 @@ RUN set -eux; \
 	mkdir -p /home/rootless/.local/share/docker; \
 	chown -R rootless:rootless /home/rootless/.local/share/docker
 VOLUME /home/rootless/.local/share/docker
-USER rootless
+USER 1000

--- a/Dockerfile-dind-rootless.template
+++ b/Dockerfile-dind-rootless.template
@@ -43,4 +43,4 @@ RUN set -eux; \
 	mkdir -p /home/rootless/.local/share/docker; \
 	chown -R rootless:rootless /home/rootless/.local/share/docker
 VOLUME /home/rootless/.local/share/docker
-USER rootless
+USER 100000


### PR DESCRIPTION
Systems configured to disallow running images as root aren't able to run images that use user name string values for the USER because they can't validate that a named user isn't root. To allow this image to run on such systems, use the uid of the user as the value for USER instead of the username.

See: https://github.com/kubernetes/kubernetes/pull/56503