### PR TITLE
feat: use `util-linux` to replace `busybox`

### DIFF
--- a/28/cli/Dockerfile
+++ b/28/cli/Dockerfile
@@ -11,7 +11,9 @@ RUN apk add --no-cache \
 # DOCKER_HOST=ssh://... -- https://github.com/docker/cli/pull/1014
 		openssh-client \
 # https://github.com/docker-library/docker/issues/482#issuecomment-2197116408
-		git
+		git \
+# https://github.com/docker-library/busybox/issues/230
+		mount
 
 # ensure that nsswitch.conf is set up for Go's "netgo" implementation (which Docker explicitly uses)
 # - https://github.com/moby/moby/blob/v24.0.6/hack/make.sh#L111

--- a/28/dind-rootless/Dockerfile
+++ b/28/dind-rootless/Dockerfile
@@ -9,7 +9,7 @@ FROM docker:28-dind
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1
 # slirp4netns can be selected as rootlesskit's net driver using "-e DOCKERD_ROOTLESS_ROOTLESSKIT_NET=slirp4netns"
-RUN apk add --no-cache iproute2 fuse-overlayfs slirp4netns
+RUN apk add --no-cache iproute2 fuse-overlayfs slirp4netns mount
 
 # "/run/user/UID" will be used by default as the value of XDG_RUNTIME_DIR
 RUN mkdir /run/user && chmod 1777 /run/user

--- a/28/dind/Dockerfile
+++ b/28/dind/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux; \
 		xfsprogs \
 		xz \
 		zfs \
+		mount \
 	;
 
 # dind might be used on systems where the nf_tables kernel module isn't available. In that case,

--- a/Dockerfile-cli.template
+++ b/Dockerfile-cli.template
@@ -6,7 +6,9 @@ RUN apk add --no-cache \
 # DOCKER_HOST=ssh://... -- https://github.com/docker/cli/pull/1014
 		openssh-client \
 # https://github.com/docker-library/docker/issues/482#issuecomment-2197116408
-		git
+		git \
+# https://github.com/docker-library/busybox/issues/230
+		mount
 
 # ensure that nsswitch.conf is set up for Go's "netgo" implementation (which Docker explicitly uses)
 # - https://github.com/moby/moby/blob/v24.0.6/hack/make.sh#L111

--- a/Dockerfile-dind-rootless.template
+++ b/Dockerfile-dind-rootless.template
@@ -4,7 +4,7 @@ FROM docker:{{ env.version }}-dind
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1
 # slirp4netns can be selected as rootlesskit's net driver using "-e DOCKERD_ROOTLESS_ROOTLESSKIT_NET=slirp4netns"
-RUN apk add --no-cache iproute2 fuse-overlayfs slirp4netns
+RUN apk add --no-cache iproute2 fuse-overlayfs slirp4netns mount
 
 # "/run/user/UID" will be used by default as the value of XDG_RUNTIME_DIR
 RUN mkdir /run/user && chmod 1777 /run/user

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -17,6 +17,7 @@ RUN set -eux; \
 		xfsprogs \
 		xz \
 		zfs \
+		mount \
 	;
 
 # dind might be used on systems where the nf_tables kernel module isn't available. In that case,


### PR DESCRIPTION
resolve https://github.com/docker-library/busybox/issues/230