### PR TITLE
Update to Alpine 3.23

### DIFF
--- a/29/cli/Dockerfile
+++ b/29/cli/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.22
+FROM alpine:3.23
 
 RUN apk add --no-cache \
 		ca-certificates \

--- a/29/dind/Dockerfile
+++ b/29/dind/Dockerfile
@@ -40,7 +40,7 @@ RUN set -eux; \
 		ip6tables-restore \
 	; do \
 # "iptables-save" -> "iptables-legacy-save", "ip6tables" -> "ip6tables-legacy", etc.
-# https://pkgs.alpinelinux.org/contents?branch=v3.22&name=iptables-legacy&arch=x86_64
+# https://pkgs.alpinelinux.org/contents?branch=v3.23&name=iptables-legacy&arch=x86_64
 		b="$(command -v "${f/tables/tables-legacy}")"; \
 		"$b" --version; \
 		ln -svT "$b" "/usr/local/sbin/.iptables-legacy/$f"; \

--- a/Dockerfile-cli.template
+++ b/Dockerfile-cli.template
@@ -1,5 +1,5 @@
 {{ include "shared" -}}
-FROM alpine:3.22
+FROM alpine:3.23
 
 RUN apk add --no-cache \
 		ca-certificates \

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -35,7 +35,7 @@ RUN set -eux; \
 		ip6tables-restore \
 	; do \
 # "iptables-save" -> "iptables-legacy-save", "ip6tables" -> "ip6tables-legacy", etc.
-# https://pkgs.alpinelinux.org/contents?branch=v3.22&name=iptables-legacy&arch=x86_64
+# https://pkgs.alpinelinux.org/contents?branch=v3.23&name=iptables-legacy&arch=x86_64
 		b="$(command -v "${f/tables/tables-legacy}")"; \
 		"$b" --version; \
 		ln -svT "$b" "/usr/local/sbin/.iptables-legacy/$f"; \


### PR DESCRIPTION
Modelled after #540.

Requires https://github.com/docker-library/official-images/pull/20400.

This PR updates Alpine to the latest stable version: 3.23.

See also https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.23.0.