### PR TITLE
Add 29.5.0

### DIFF
--- a/29/cli/Dockerfile
+++ b/29/cli/Dockerfile
@@ -23,23 +23,23 @@ RUN [ -e /etc/nsswitch.conf ] && grep '^hosts: files dns' /etc/nsswitch.conf
 RUN set -eux; \
 	addgroup -g 2375 -S docker
 
-ENV DOCKER_VERSION 29.4.3
+ENV DOCKER_VERSION 29.5.0
 
 RUN set -eux; \
 	\
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
 		'x86_64') \
-			url='https://download.docker.com/linux/static/stable/x86_64/docker-29.4.3.tgz'; \
+			url='https://download.docker.com/linux/static/stable/x86_64/docker-29.5.0.tgz'; \
 			;; \
 		'armhf') \
-			url='https://download.docker.com/linux/static/stable/armel/docker-29.4.3.tgz'; \
+			url='https://download.docker.com/linux/static/stable/armel/docker-29.5.0.tgz'; \
 			;; \
 		'armv7') \
-			url='https://download.docker.com/linux/static/stable/armhf/docker-29.4.3.tgz'; \
+			url='https://download.docker.com/linux/static/stable/armhf/docker-29.5.0.tgz'; \
 			;; \
 		'aarch64') \
-			url='https://download.docker.com/linux/static/stable/aarch64/docker-29.4.3.tgz'; \
+			url='https://download.docker.com/linux/static/stable/aarch64/docker-29.5.0.tgz'; \
 			;; \
 		*) echo >&2 "error: unsupported 'docker.tgz' architecture ($apkArch)"; exit 1 ;; \
 	esac; \

--- a/29/dind-rootless/Dockerfile
+++ b/29/dind-rootless/Dockerfile
@@ -8,7 +8,8 @@ FROM docker:29-dind
 
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1
-# slirp4netns can be selected as rootlesskit's net driver using "-e DOCKERD_ROOTLESS_ROOTLESSKIT_NET=slirp4netns"
+# slirp4netns is recommended as rootlesskit's net driver
+# https://github.com/rootless-containers/rootlesskit/blob/be156df0429551f5c23dc61dd07201b33076ff1d/docs/network.md#--netslirp4netns-recommended
 RUN apk add --no-cache iproute2 fuse-overlayfs slirp4netns
 
 # "/run/user/UID" will be used by default as the value of XDG_RUNTIME_DIR
@@ -25,10 +26,10 @@ RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
 		'x86_64') \
-			url='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-29.4.3.tgz'; \
+			url='https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-29.5.0.tgz'; \
 			;; \
 		'aarch64') \
-			url='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-29.4.3.tgz'; \
+			url='https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-29.5.0.tgz'; \
 			;; \
 		*) echo >&2 "error: unsupported 'rootless.tgz' architecture ($apkArch)"; exit 1 ;; \
 	esac; \
@@ -40,12 +41,10 @@ RUN set -eux; \
 		--strip-components 1 \
 		--directory /usr/local/bin/ \
 		'docker-rootless-extras/rootlesskit' \
-		'docker-rootless-extras/vpnkit' \
 	; \
 	rm rootless.tgz; \
 	\
-	rootlesskit --version; \
-	vpnkit --version
+	rootlesskit --version
 
 # pre-create "/var/lib/docker" for our rootless user
 RUN set -eux; \

--- a/29/dind/Dockerfile
+++ b/29/dind/Dockerfile
@@ -61,16 +61,16 @@ RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
 		'x86_64') \
-			url='https://download.docker.com/linux/static/stable/x86_64/docker-29.4.3.tgz'; \
+			url='https://download.docker.com/linux/static/stable/x86_64/docker-29.5.0.tgz'; \
 			;; \
 		'armhf') \
-			url='https://download.docker.com/linux/static/stable/armel/docker-29.4.3.tgz'; \
+			url='https://download.docker.com/linux/static/stable/armel/docker-29.5.0.tgz'; \
 			;; \
 		'armv7') \
-			url='https://download.docker.com/linux/static/stable/armhf/docker-29.4.3.tgz'; \
+			url='https://download.docker.com/linux/static/stable/armhf/docker-29.5.0.tgz'; \
 			;; \
 		'aarch64') \
-			url='https://download.docker.com/linux/static/stable/aarch64/docker-29.4.3.tgz'; \
+			url='https://download.docker.com/linux/static/stable/aarch64/docker-29.5.0.tgz'; \
 			;; \
 		*) echo >&2 "error: unsupported 'docker.tgz' architecture ($apkArch)"; exit 1 ;; \
 	esac; \

--- a/29/dind/dockerd-entrypoint.sh
+++ b/29/dind/dockerd-entrypoint.sh
@@ -218,7 +218,7 @@ if [ "$1" = 'dockerd' ]; then
 		fi
 		# TODO overlay support detection?
 		exec rootlesskit \
-			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-slirp4netns}" \
 			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
 			--disable-host-loopback \
 			--port-driver=builtin \

--- a/29/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/29/windows/windowsservercore-ltsc2022/Dockerfile
@@ -15,8 +15,8 @@ RUN $newPath = ('{0}\docker;{1}' -f $env:ProgramFiles, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV DOCKER_VERSION 29.4.3
-ENV DOCKER_URL https://download.docker.com/win/static/stable/x86_64/docker-29.4.3.zip
+ENV DOCKER_VERSION 29.5.0
+ENV DOCKER_URL https://download.docker.com/win/static/stable/x86_64/docker-29.5.0.zip
 # TODO ENV DOCKER_SHA256
 # https://github.com/docker/docker-ce/blob/5b073ee2cf564edee5adca05eee574142f7627bb/components/packaging/static/hash_files !!
 # (no SHA file artifacts on download.docker.com yet as of 2017-06-07 though)

--- a/29/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/29/windows/windowsservercore-ltsc2025/Dockerfile
@@ -15,8 +15,8 @@ RUN $newPath = ('{0}\docker;{1}' -f $env:ProgramFiles, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV DOCKER_VERSION 29.4.3
-ENV DOCKER_URL https://download.docker.com/win/static/stable/x86_64/docker-29.4.3.zip
+ENV DOCKER_VERSION 29.5.0
+ENV DOCKER_URL https://download.docker.com/win/static/stable/x86_64/docker-29.5.0.zip
 # TODO ENV DOCKER_SHA256
 # https://github.com/docker/docker-ce/blob/5b073ee2cf564edee5adca05eee574142f7627bb/components/packaging/static/hash_files !!
 # (no SHA file artifacts on download.docker.com yet as of 2017-06-07 though)

--- a/Dockerfile-dind-rootless.template
+++ b/Dockerfile-dind-rootless.template
@@ -3,7 +3,8 @@ FROM docker:{{ env.version }}-dind
 
 # busybox "ip" is insufficient:
 #   [rootlesskit:child ] error: executing [[ip tuntap add name tap0 mode tap] [ip link set tap0 address 02:50:00:00:00:01]]: exit status 1
-# slirp4netns can be selected as rootlesskit's net driver using "-e DOCKERD_ROOTLESS_ROOTLESSKIT_NET=slirp4netns"
+# slirp4netns is recommended as rootlesskit's net driver
+# https://github.com/rootless-containers/rootlesskit/blob/be156df0429551f5c23dc61dd07201b33076ff1d/docs/network.md#--netslirp4netns-recommended
 RUN apk add --no-cache iproute2 fuse-overlayfs slirp4netns
 
 # "/run/user/UID" will be used by default as the value of XDG_RUNTIME_DIR
@@ -31,12 +32,10 @@ RUN set -eux; \
 		--strip-components 1 \
 		--directory /usr/local/bin/ \
 		'docker-rootless-extras/rootlesskit' \
-		'docker-rootless-extras/vpnkit' \
 	; \
 	rm rootless.tgz; \
 	\
-	rootlesskit --version; \
-	vpnkit --version
+	rootlesskit --version
 
 # pre-create "/var/lib/docker" for our rootless user
 RUN set -eux; \

--- a/dockerd-entrypoint.sh
+++ b/dockerd-entrypoint.sh
@@ -218,7 +218,7 @@ if [ "$1" = 'dockerd' ]; then
 		fi
 		# TODO overlay support detection?
 		exec rootlesskit \
-			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-vpnkit}" \
+			--net="${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:-slirp4netns}" \
 			--mtu="${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:-1500}" \
 			--disable-host-loopback \
 			--port-driver=builtin \

--- a/versions.json
+++ b/versions.json
@@ -2,21 +2,21 @@
   "29": {
     "arches": {
       "amd64": {
-        "dockerUrl": "https://download.docker.com/linux/static/stable/x86_64/docker-29.4.3.tgz",
-        "rootlessExtrasUrl": "https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-29.4.3.tgz"
+        "dockerUrl": "https://download.docker.com/linux/static/stable/x86_64/docker-29.5.0.tgz",
+        "rootlessExtrasUrl": "https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-29.5.0.tgz"
       },
       "arm32v6": {
-        "dockerUrl": "https://download.docker.com/linux/static/stable/armel/docker-29.4.3.tgz"
+        "dockerUrl": "https://download.docker.com/linux/static/stable/armel/docker-29.5.0.tgz"
       },
       "arm32v7": {
-        "dockerUrl": "https://download.docker.com/linux/static/stable/armhf/docker-29.4.3.tgz"
+        "dockerUrl": "https://download.docker.com/linux/static/stable/armhf/docker-29.5.0.tgz"
       },
       "arm64v8": {
-        "dockerUrl": "https://download.docker.com/linux/static/stable/aarch64/docker-29.4.3.tgz",
-        "rootlessExtrasUrl": "https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-29.4.3.tgz"
+        "dockerUrl": "https://download.docker.com/linux/static/stable/aarch64/docker-29.5.0.tgz",
+        "rootlessExtrasUrl": "https://download.docker.com/linux/static/stable/aarch64/docker-rootless-extras-29.5.0.tgz"
       },
       "windows-amd64": {
-        "dockerUrl": "https://download.docker.com/win/static/stable/x86_64/docker-29.4.3.zip"
+        "dockerUrl": "https://download.docker.com/win/static/stable/x86_64/docker-29.5.0.zip"
       }
     },
     "buildx": {
@@ -167,7 +167,7 @@
       "windows/windowsservercore-ltsc2025",
       "windows/windowsservercore-ltsc2022"
     ],
-    "version": "29.4.3"
+    "version": "29.5.0"
   },
   "29-rc": null
 }


### PR DESCRIPTION
`vpnkit` is no longer included in the `docker-rootless-extras-*.tgz` and is no longer necessary for RootlessKit 3.0.0: https://github.com/moby/moby/pull/52319

Since it is no longer included, the automated update job cannot successfully build the `29.5.0` release:
```console
+ wget -O rootless.tgz https://download.docker.com/linux/static/test/x86_64/docker-rootless-extras-29.5.0.tgz
...
+ tar --extract --file rootless.tgz --strip-components 1 --directory /usr/local/bin/ docker-rootless-extras/rootlesskit docker-rootless-extras/vpnkit
tar: docker-rootless-extras/vpnkit: not found in archive
```