### PR TITLE
dind: remove obsolete runtime dependencies

### DIFF
--- a/29/dind/Dockerfile
+++ b/29/dind/Dockerfile
@@ -10,7 +10,6 @@ FROM docker:29-cli
 # https://github.com/docker/docker-ce-packaging/blob/963aa02666035d4e268f33c63d7868d6cdd1d34c/deb/common/control#L28-L41
 RUN set -eux; \
 	apk add --no-cache \
-		btrfs-progs \
 		e2fsprogs \
 		e2fsprogs-extra \
 		git \

--- a/29/dind/Dockerfile
+++ b/29/dind/Dockerfile
@@ -10,7 +10,6 @@ FROM docker:29-cli
 # https://github.com/docker/docker-ce-packaging/blob/963aa02666035d4e268f33c63d7868d6cdd1d34c/deb/common/control#L28-L41
 RUN set -eux; \
 	apk add --no-cache \
-		git \
 		ip6tables \
 		iptables \
 		openssl \

--- a/29/dind/Dockerfile
+++ b/29/dind/Dockerfile
@@ -6,8 +6,9 @@
 
 FROM docker:29-cli
 
-# https://github.com/moby/moby/blob/0eecd59153c03ced5f5ddd79cc98f29e4d86daec/project/PACKAGERS.md#runtime-dependencies
-# https://github.com/docker/docker-ce-packaging/blob/963aa02666035d4e268f33c63d7868d6cdd1d34c/deb/common/control#L28-L41
+# Runtime dependencies:
+# - https://github.com/moby/moby/blob/864598f8c2677189e308eb4a3b3c0dd41fc06599/project/PACKAGERS.md#runtime-dependencies#runtime-dependencies
+# - https://github.com/docker/packaging/blob/0ba325d178593583f190dc91566214a85c3880ad/pkg/docker-engine/deb/control#L24-L36
 RUN set -eux; \
 	apk add --no-cache \
 		ip6tables \

--- a/29/dind/Dockerfile
+++ b/29/dind/Dockerfile
@@ -10,15 +10,12 @@ FROM docker:29-cli
 # https://github.com/docker/docker-ce-packaging/blob/963aa02666035d4e268f33c63d7868d6cdd1d34c/deb/common/control#L28-L41
 RUN set -eux; \
 	apk add --no-cache \
-		e2fsprogs \
-		e2fsprogs-extra \
 		git \
 		ip6tables \
 		iptables \
 		openssl \
 		pigz \
 		shadow-uidmap \
-		xfsprogs \
 		xz \
 		zfs \
 	;

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -5,7 +5,6 @@ FROM docker:{{ env.version }}-cli
 # https://github.com/docker/docker-ce-packaging/blob/963aa02666035d4e268f33c63d7868d6cdd1d34c/deb/common/control#L28-L41
 RUN set -eux; \
 	apk add --no-cache \
-		git \
 		ip6tables \
 		iptables \
 		openssl \

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -5,15 +5,12 @@ FROM docker:{{ env.version }}-cli
 # https://github.com/docker/docker-ce-packaging/blob/963aa02666035d4e268f33c63d7868d6cdd1d34c/deb/common/control#L28-L41
 RUN set -eux; \
 	apk add --no-cache \
-		e2fsprogs \
-		e2fsprogs-extra \
 		git \
 		ip6tables \
 		iptables \
 		openssl \
 		pigz \
 		shadow-uidmap \
-		xfsprogs \
 		xz \
 		zfs \
 	;

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -5,7 +5,6 @@ FROM docker:{{ env.version }}-cli
 # https://github.com/docker/docker-ce-packaging/blob/963aa02666035d4e268f33c63d7868d6cdd1d34c/deb/common/control#L28-L41
 RUN set -eux; \
 	apk add --no-cache \
-		btrfs-progs \
 		e2fsprogs \
 		e2fsprogs-extra \
 		git \

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -1,8 +1,9 @@
 {{ include "shared" -}}
 FROM docker:{{ env.version }}-cli
 
-# https://github.com/moby/moby/blob/0eecd59153c03ced5f5ddd79cc98f29e4d86daec/project/PACKAGERS.md#runtime-dependencies
-# https://github.com/docker/docker-ce-packaging/blob/963aa02666035d4e268f33c63d7868d6cdd1d34c/deb/common/control#L28-L41
+# Runtime dependencies:
+# - https://github.com/moby/moby/blob/864598f8c2677189e308eb4a3b3c0dd41fc06599/project/PACKAGERS.md#runtime-dependencies#runtime-dependencies
+# - https://github.com/docker/packaging/blob/0ba325d178593583f190dc91566214a85c3880ad/pkg/docker-engine/deb/control#L24-L36
 RUN set -eux; \
 	apk add --no-cache \
 		ip6tables \


### PR DESCRIPTION
## dind: remove obsolete runtime dependencies

### dind: remove btrfs-progs dependency

The btrfs storage driver no longer requires the btrfs userspace
utilities at runtime.

Moby switched its btrfs implementation to use the kernel UAPI directly
in v23.0, removing its dependency on libbtrfs/btrfs-progs.

Containerd similarly switched its btrfs snapshotter to use the kernel
UAPI through containerd/btrfs/v2 in containerd 1.7, making kernel
headers a build-time dependency instead of requiring btrfs-progs at
runtime.

Remove btrfs-progs from the dind image, as neither the Moby btrfs
storage driver nor containerd's btrfs snapshotter requires it.

- https://github.com/moby/moby/commit/3208dcabdc8997340b255f5b880fef4e3f54580d
- https://github.com/containerd/containerd/commit/52f82acb7b3984fcb143af50c29a0ac0ceb5dc5d

### dind: remove e2fsprogs and xfsprogs dependencies

The e2fsprogs, e2fsprogs-extra, and xfsprogs packages were runtime
dependencies of the devicemapper storage driver, providing the tools
used to create and configure ext4 and XFS filesystems.

The devicemapper storage driver was disabled by default in Docker
Engine v23.0 and removed in v25.0. None of these filesystem utilities
are required by the remaining storage drivers.

Remove e2fsprogs, e2fsprogs-extra, and xfsprogs from the dind image.

- https://docs.docker.com/engine/deprecated/#device-mapper-storage-driver

### dind: remove duplicate git dependency

Git was originally added explicitly to the dind variants when the
separate git variant was folded into dind.

It was later added to the CLI variants as well, to support build and
buildx workflows that invoke git. As the dind image is based on the CLI
image, git is now inherited from its parent and no longer needs to be
installed again.

Remove the redundant git package from the dind dependencies.

- https://github.com/docker-library/docker/commit/485fefe743baed5a2dd9e5d22b685c14eda4c61e
- https://github.com/docker-library/docker/commit/b348a31fc955dd6500a4aa9537bbef51688a181e


### dind: update links for runtime-dependencies
