### PR TITLE
dind: remove zfs dependency

### DIFF
--- a/29/dind/Dockerfile
+++ b/29/dind/Dockerfile
@@ -17,7 +17,6 @@ RUN set -eux; \
 		pigz \
 		shadow-uidmap \
 		xz \
-		zfs \
 	;
 
 # dind might be used on systems where the nf_tables kernel module isn't available. In that case,

--- a/Dockerfile-dind.template
+++ b/Dockerfile-dind.template
@@ -12,7 +12,6 @@ RUN set -eux; \
 		pigz \
 		shadow-uidmap \
 		xz \
-		zfs \
 	;
 
 # dind might be used on systems where the nf_tables kernel module isn't available. In that case,


### PR DESCRIPTION
- follow-up to https://github.com/docker-library/docker/pull/584#discussion_r3937818504

The zfs utilities were used by the zfs graph-driver. containerd provides an optional zfs-snapshotter, but it's not installed by default. Remove the dependency, as it's not used in the default configuration.